### PR TITLE
BUG set LBox properly for gpairs

### DIFF
--- a/native/gpairs/CPU/data_gen.cpp
+++ b/native/gpairs/CPU/data_gen.cpp
@@ -72,14 +72,14 @@ void InitData(int npoints, tfloat **x1, tfloat **y1, tfloat **z1, tfloat **w1,
 #pragma omp for simd
     for ( i = 0; i < npoints; i++ )
       {
-	(*x1)[i] = RandRange( 0.0, TL, &seed );
-	(*y1)[i] = RandRange( 0.0, TL, &seed );
-	(*z1)[i] = RandRange( 0.0, TL, &seed );
+	(*x1)[i] = RandRange( 0.0, LBOX, &seed );
+	(*y1)[i] = RandRange( 0.0, LBOX, &seed );
+	(*z1)[i] = RandRange( 0.0, LBOX, &seed );
 	(*w1)[i] = RandRange( 0.0, TL, &seed );
 
-	(*x2)[i] = RandRange( 0.0, TL, &seed );
-	(*y2)[i] = RandRange( 0.0, TL, &seed );
-	(*z2)[i] = RandRange( 0.0, TL, &seed );
+	(*x2)[i] = RandRange( 0.0, LBOX, &seed );
+	(*y2)[i] = RandRange( 0.0, LBOX, &seed );
+	(*z2)[i] = RandRange( 0.0, LBOX, &seed );
 	(*w2)[i] = RandRange( 0.0, TL, &seed );
       }
   }

--- a/native/gpairs/CPU/euro_opt.h
+++ b/native/gpairs/CPU/euro_opt.h
@@ -18,6 +18,7 @@
 #define SEED 43
 
 #define TL      1.0f
+#define LBOX    500.0f
 #define DEFAULT_NBINS 20
 
 void InitData( int npoints, tfloat **x1, tfloat **y1, tfloat **z1, tfloat **w1,

--- a/native/gpairs/GPU/data_gen.cpp
+++ b/native/gpairs/GPU/data_gen.cpp
@@ -72,14 +72,14 @@ void InitData(int npoints, tfloat **x1, tfloat **y1, tfloat **z1, tfloat **w1,
 #pragma omp for simd
     for ( i = 0; i < npoints; i++ )
       {
-	(*x1)[i] = RandRange( 0.0, TL, &seed );
-	(*y1)[i] = RandRange( 0.0, TL, &seed );
-	(*z1)[i] = RandRange( 0.0, TL, &seed );
+	(*x1)[i] = RandRange( 0.0, LBOX, &seed );
+	(*y1)[i] = RandRange( 0.0, LBOX, &seed );
+	(*z1)[i] = RandRange( 0.0, LBOX, &seed );
 	(*w1)[i] = RandRange( 0.0, TL, &seed );
 
-	(*x2)[i] = RandRange( 0.0, TL, &seed );
-	(*y2)[i] = RandRange( 0.0, TL, &seed );
-	(*z2)[i] = RandRange( 0.0, TL, &seed );
+	(*x2)[i] = RandRange( 0.0, LBOX, &seed );
+	(*y2)[i] = RandRange( 0.0, LBOX, &seed );
+	(*z2)[i] = RandRange( 0.0, LBOX, &seed );
 	(*w2)[i] = RandRange( 0.0, TL, &seed );
       }
   }

--- a/native/gpairs/GPU/euro_opt.h
+++ b/native/gpairs/GPU/euro_opt.h
@@ -18,6 +18,7 @@
 #define SEED 43
 
 #define TL      1.0f
+#define LBOX    500.0f
 #define DEFAULT_NBINS 20
 
 void InitData( int npoints, tfloat **x1, tfloat **y1, tfloat **z1, tfloat **w1,


### PR DESCRIPTION
It appears that the native version of gpairs is using the wrong box length for the points. 