### PR TITLE
Introduce decorators wrapper

### DIFF
--- a/numba/blackscholes/CPU/bs_erf_numba_jit_par.py
+++ b/numba/blackscholes/CPU/bs_erf_numba_jit_par.py
@@ -6,9 +6,10 @@ import dpctl
 import base_bs_erf
 import numba as nb
 from math import log, sqrt, exp, erf
+from dpbench_decorators import njit
 
 # blackscholes implemented as a parallel loop using numba.prange
-@nb.njit(parallel=True, fastmath=True)
+@njit(parallel=True, fastmath=True)
 def black_scholes_kernel(nopt, price, strike, t, rate, vol, call, put):
     mr = -rate
     sig_sig_two = vol * vol * 2

--- a/numba/blackscholes/CPU/bs_erf_numba_numpy.py
+++ b/numba/blackscholes/CPU/bs_erf_numba_numpy.py
@@ -3,19 +3,19 @@
 # SPDX-License-Identifier: MIT
 
 import base_bs_erf
-import numba as nb
 import numpy as np
 from numpy import log, exp, sqrt
 from math import erf
+from dpbench_decorators import jit, vectorize
 
 # Numba does know erf function from numpy or scipy
-@nb.vectorize(nopython=True)
+@vectorize(nopython=True)
 def nberf(x):
     return erf(x)
 
 
 # blackscholes implemented using numpy function calls
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def black_scholes_kernel(nopt, price, strike, t, rate, vol, call, put):
     mr = -rate
     sig_sig_two = vol * vol * 2

--- a/numba/dbscan/CPU/dbscan.py
+++ b/numba/dbscan/CPU/dbscan.py
@@ -25,9 +25,10 @@
 # *****************************************************************************
 
 import numpy as np
-from numba import jit, prange
+from numba import prange
 import base_dbscan
 import utils
+from dpbench_decorators import jit
 
 NOISE = -1
 UNDEFINED = -2

--- a/numba/gpairs/CPU/gaussian_weighted_pair_counts.py
+++ b/numba/gpairs/CPU/gaussian_weighted_pair_counts.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-# from numba import njit
-from numba import njit
+from dpbench_decorators import njit
 
 try:
     import numba_dppy

--- a/numba/kmeans/CPU/kmeans.py
+++ b/numba/kmeans/CPU/kmeans.py
@@ -1,13 +1,14 @@
 import base_kmeans
 import numpy
 import numba
+from dpbench_decorators import jit
 
 REPEAT = 1
 
 ITERATIONS = 30
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     for i0 in numba.prange(num_points):
         minor_distance = -1
@@ -21,7 +22,7 @@ def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     return arrayPcluster
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def calCentroidsSum(
     arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points, num_centroids
 ):
@@ -39,7 +40,7 @@ def calCentroidsSum(
     return arrayCsum, arrayCnumpoint
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
     for i in numba.prange(num_centroids):
         arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]

--- a/numba/knn/CPU/knn.py
+++ b/numba/knn/CPU/knn.py
@@ -27,9 +27,10 @@
 import numpy as np
 import numba
 import base_knn
+from dpbench_decorators import jit
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def euclidean_dist(x1, x2):
     distance = 0
 
@@ -42,7 +43,7 @@ def euclidean_dist(x1, x2):
     return result
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def push_queue(queue_neighbors, new_distance, index=4):
     while index > 0 and new_distance[0] < queue_neighbors[index - 1][0]:
         queue_neighbors[index] = queue_neighbors[index - 1]
@@ -50,13 +51,13 @@ def push_queue(queue_neighbors, new_distance, index=4):
         queue_neighbors[index] = new_distance
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def sort_queue(queue_neighbors):
     for i in range(len(queue_neighbors)):
         push_queue(queue_neighbors, queue_neighbors[i], i)
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def simple_vote(neighbors, classes_num=3):
     votes_to_classes = np.zeros(classes_num)
 
@@ -74,7 +75,7 @@ def simple_vote(neighbors, classes_num=3):
     return max_ind
 
 
-@numba.jit(nopython=True, parallel=True)
+@jit(nopython=True, parallel=True)
 def run_knn(train, train_labels, test, k=5, classes_num=3):
     test_size = len(test)
     train_size = len(train)

--- a/numba/l2_distance/CPU/l2_distance.py
+++ b/numba/l2_distance/CPU/l2_distance.py
@@ -5,10 +5,9 @@
 
 import base_l2_distance
 import numpy as np
-import numba
+from dpbench_decorators import jit
 
-
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def l2_distance(a, b):
     sub = a - b
     sq = np.square(sub)

--- a/numba/l2_distance/CPU/l2_distance.py
+++ b/numba/l2_distance/CPU/l2_distance.py
@@ -7,6 +7,7 @@ import base_l2_distance
 import numpy as np
 from dpbench_decorators import jit
 
+
 @jit(nopython=True, parallel=True, fastmath=True)
 def l2_distance(a, b):
     sub = a - b

--- a/numba/pairwise_distance/CPU/pairwise_distance.py
+++ b/numba/pairwise_distance/CPU/pairwise_distance.py
@@ -6,9 +6,10 @@
 import base_pair_wise
 import numpy as np
 import numba
+from dpbench_decorators import jit
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def pw_distance(X1, X2, D):
     M = X1.shape[0]
     N = X2.shape[0]

--- a/numba/pairwise_distance/CPU/pw_numba.py
+++ b/numba/pairwise_distance/CPU/pw_numba.py
@@ -5,10 +5,10 @@
 
 import base_pair_wise
 import numpy as np
-import numba
+from dpbench_decorators import jit
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def pw_distance(X1, X2, D):
     # return np.sqrt((np.square(X1 - X2.reshape((X2.shape[0],1,X2.shape[1])))).sum(axis=2))
     x1 = np.sum(np.square(X1), axis=1)  # X1=4*3 -> 4*1

--- a/numba/pca/CPU/pca.py
+++ b/numba/pca/CPU/pca.py
@@ -8,6 +8,7 @@ import numba
 import numpy as np
 from dpbench_decorators import jit
 
+
 @jit(nopython=True, parallel=True, fastmath=True)
 def pca_impl(data):
     tdata = data.T

--- a/numba/pca/CPU/pca.py
+++ b/numba/pca/CPU/pca.py
@@ -6,9 +6,9 @@
 import base_pca
 import numba
 import numpy as np
+from dpbench_decorators import jit
 
-
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def pca_impl(data):
     tdata = data.T
     m = np.empty(tdata.shape[0])

--- a/numba/rambo/CPU/rambo_wo_mkl.py
+++ b/numba/rambo/CPU/rambo_wo_mkl.py
@@ -4,6 +4,7 @@ import numpy
 import numba
 from dpbench_decorators import jit
 
+
 @jit(nopython=True, fastmath=True)
 def vectmultiply(a, b):
     c = a * b

--- a/numba/rambo/CPU/rambo_wo_mkl.py
+++ b/numba/rambo/CPU/rambo_wo_mkl.py
@@ -2,9 +2,9 @@
 import base_rambo
 import numpy
 import numba
+from dpbench_decorators import jit
 
-
-@numba.jit(nopython=True, fastmath=True)
+@jit(nopython=True, fastmath=True)
 def vectmultiply(a, b):
     c = a * b
     return c[..., 0] - c[..., 1] - c[..., 2] - c[..., 3]
@@ -20,25 +20,25 @@ def get_inputs(ecms, nevts):
     return input_particles
 
 
-@numba.jit(nopython=True, fastmath=True)
+@jit(nopython=True, fastmath=True)
 def get_momentum_sum(inarray):
     return numpy.sum(inarray, axis=1)
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def get_combined_mass(inarray):
     sum = get_momentum_sum(inarray)
     return get_mass(sum)
 
 
-@numba.jit(nopython=True, fastmath=True)
+@jit(nopython=True, fastmath=True)
 def get_mass(inarray):
     mom2 = numpy.sum(inarray[..., 1:4] ** 2, axis=1)
     mass = numpy.sqrt(inarray[..., 0] ** 2 - mom2)
     return mass
 
 
-@numba.jit(nopython=True)
+@jit(nopython=True)
 def gen_rand_data(nevts, nout):
     C1 = numpy.empty((nevts, nout))
     F1 = numpy.empty((nevts, nout))
@@ -54,7 +54,7 @@ def gen_rand_data(nevts, nout):
     return C1, F1, Q1
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@jit(nopython=True, parallel=True, fastmath=True)
 def get_output_mom2(C1, F1, Q1, nevts, nout):
     output = numpy.empty((nevts, nout, 4))
 

--- a/utils/dpbench_decorators.py
+++ b/utils/dpbench_decorators.py
@@ -1,0 +1,27 @@
+# *****************************************************************************
+# Copyright (c) 2020, Intel Corporation All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#     Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *****************************************************************************
+
+from numba import jit, njit, vectorize


### PR DESCRIPTION
Add wrappers for numba decorators, so they all can be replaced from one place in the future (e.g to run our MLIR compiler instead of numba). Update some workloads to use new decorators (numba CPU only for now).