### PR TITLE
Fix Validation

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -51,3 +51,11 @@ jobs:
         shell: bash -l {0}
         run: |
           python -c "import dpbench; dpbench.run_benchmarks()" || exit 1
+          python -c "import dpbench; dpbench.all_benchmarks_passed_validation(\"dpbench.db\");"
+          res=`                                                                    \
+            printf "%s"                                                            \
+            "$(python -c "import dpbench;                                          \
+                res=int(dpbench.all_benchmarks_passed_validation(\"dpbench.db\")); \
+                print(\"Validation:\",res)"                                        \
+              )" | grep Validation | cut -f 2 -d ":"` || exit 1
+          if [ ${res} == 0 ]; then exit 1; fi

--- a/dpbench/__init__.py
+++ b/dpbench/__init__.py
@@ -2,6 +2,14 @@
 #
 # SPDX-License-Identifier: Apache 2.0 License
 
-from .runner import list_available_benchmarks, run_benchmarks
+from .runner import (
+    all_benchmarks_passed_validation,
+    list_available_benchmarks,
+    run_benchmarks,
+)
 
-__all__ = ["run_benchmarks", "list_available_benchmarks"]
+__all__ = [
+    "all_benchmarks_passed_validation",
+    "run_benchmarks",
+    "list_available_benchmarks",
+]

--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -6,13 +6,20 @@ from .benchmark import Benchmark
 from .framework import Framework, generate_framework
 from .numba_framework import NumbaFramework
 from .test import Test
-from .utilities import benchmark, str2bool, time_to_ms, validate
+from .utilities import (
+    benchmark,
+    create_connection,
+    str2bool,
+    time_to_ms,
+    validate,
+)
 
 __all__ = [
     "Benchmark",
     "Framework",
     "NumbaFramework",
     "Test",
+    "create_connection",
     "generate_framework",
     "benchmark",
     "validate",

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -18,6 +18,17 @@ def list_available_benchmarks():
 def run_benchmarks(
     bconfig_path=None, preset="S", repeat=1, validate=True, timeout=10.0
 ):
+    """Run all benchmarks in the dpbench benchmark directory
+
+    Args:
+        bconfig_path (str, optional): Path to benchmark configurations.
+        Defaults to None.
+        preset (str, optional): Problem size. Defaults to "S".
+        repeat (int, optional): Number of repetitions. Defaults to 1.
+        validate (bool, optional): Whether to validate against NumPy.
+        Defaults to True.
+        timeout (float, optional): Timeout setting. Defaults to 10.0.
+    """
 
     for b in list_available_benchmarks():
         bdir = "benchmarks/" + b
@@ -87,3 +98,62 @@ def run_benchmarks(
                         + b
                         + "."
                     )
+
+
+def all_benchmarks_passed_validation(dbfile):
+    """Checks the results table of the output database to confirm if all
+    benchmarks passed validation in the last run.
+
+    Args:
+        dbfile (str): Name of database with dpbench results
+    """
+
+    summary = (
+        "SELECT "
+        + "MAX(id),"
+        + "benchmark,"
+        + "framework,"
+        + "version,"
+        + "details,"
+        + "IIF(validated == 1, 'PASS', 'FAIL' ) AS result "
+        + "FROM results "
+        + "GROUP BY benchmark, framework, version, details, result "
+        + "ORDER BY benchmark, framework;"
+    )
+
+    failed_benchmark_summary = (
+        "SELECT "
+        + "MAX(id),"
+        + "benchmark,"
+        + "framework,"
+        + "version,"
+        + "details,"
+        + "IIF(validated == 1, 'PASS', 'FAIL' ) AS result "
+        + "FROM results "
+        + "WHERE validated = 0 "
+        + "GROUP BY benchmark, framework, version, details, result;"
+    )
+
+    conn = dpbi.create_connection(dbfile)
+    cur = conn.cursor()
+
+    data = cur.execute(summary)
+    print("Summary")
+    print("==============================================")
+    for row in data:
+        print(row)
+    print("==============================================")
+
+    data = cur.execute(failed_benchmark_summary)
+    fails = [row for row in data]
+
+    if fails:
+        print("Number of failing validations: ", len(fails))
+        print("==============================================")
+        for fail in fails:
+            print(fail)
+        print("==============================================")
+        return False
+    else:
+        print("All benchmarks were validated successfully")
+        return True


### PR DESCRIPTION
Npbench's test runner for validating benchmarks that did not explicitly output a result, but passed the output as an argument is broken.

The `Test._execute` function in `test.py` first copies an output argument array to a new copy using the framework's copy function. For validation, these copies need to be used, but the copy operation was executed inside the `timeit` package during the setup step. `timeit` never added the copy arrays to the global namespace (the `ldict` dictionary). Thus, when populating the `out` value the dictionary lookup raises a `KeyError` in the following code in `Test._execute`.

```
        if "output_args" in self.bench.info.keys():
            out += [ldict[a] for a in frmwrk.args(self.bench)]
        return out, timelist
```
The reason it was not flagged is because of another ancillary bug: the list of output arguments for a benchmark are stored in the `bench.info` dictionary against the `output_args` key and not `out_args`.

The PR fixes the issues and now when validation says "SUCCEEDED" it really means so!