### PR TITLE
Python module destination must be a path from the root of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(dpbench
 find_package(pybind11 CONFIG REQUIRED)
 find_package(IntelDPCPP REQUIRED)
 find_package(PythonExtensions REQUIRED)
-find_package (Python3 COMPONENTS NumPy Development)
+find_package(Python3 COMPONENTS NumPy Development)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/CMakeLists.txt
@@ -5,6 +5,8 @@ pybind11_add_module(${py_module_name}
     black_scholes_sycl/_black_scholes_sycl.cpp
 )
 target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+
+file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION black_scholes_sycl
+  DESTINATION ${py_module_dest}/black_scholes_sycl
 )


### PR DESCRIPTION
Fixed destination path for `black_scholes_sycl`.