### PR TITLE
Fix Validation failure for gpairs numba object version

### DIFF
--- a/dpbench/benchmarks/gpairs/gpairs_numba_o.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_o.py
@@ -30,7 +30,7 @@ def gpairs(x1, y1, z1, w1, x2, y2, z2, w2, rbins, results):
 
             k = nbins - 1
             while dsq <= rbins[k]:
-                results[k - 1] += wprod
+                results[k] += wprod
                 k = k - 1
-                if k <= 0:
+                if k < 0:
                     break


### PR DESCRIPTION
Corrected the indexing in the gpairs numba version. Now the results of the numba-o gpairs version should match the numpy gpairs version.