### PR TITLE
Validate output only. It was using both inputs and outputs.

### DIFF
--- a/dpbench/infrastructure/test.py
+++ b/dpbench/infrastructure/test.py
@@ -63,7 +63,12 @@ class Test(object):
         else:
             out = []
         if "output_args" in self.bench.info.keys():
-            out += [ldict[a] for b in self.bench.info["output_args"] for a in frmwrk.args(self.bench) if b in a]
+            out += [
+                ldict[a]
+                for b in self.bench.info["output_args"]
+                for a in frmwrk.args(self.bench)
+                if b in a
+            ]
         return out, timelist
 
     def run(

--- a/dpbench/infrastructure/test.py
+++ b/dpbench/infrastructure/test.py
@@ -63,7 +63,7 @@ class Test(object):
         else:
             out = []
         if "output_args" in self.bench.info.keys():
-            out += [ldict[a] for a in frmwrk.args(self.bench)]
+            out += [ldict[a] for b in self.bench.info["output_args"] for a in frmwrk.args(self.bench) if b in a]
         return out, timelist
 
     def run(


### PR DESCRIPTION
The fix changes the validation logic for benchmarks, only output args are now validated.

Fixes #88 