### PR TITLE
Added native dpcpp implementation of pairwise_distance.

### DIFF
--- a/dpbench/benchmarks/CMakeLists.txt
+++ b/dpbench/benchmarks/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(black_scholes)
+add_subdirectory(pairwise_distance)

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_kernel.hpp
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_kernel.hpp
@@ -6,8 +6,8 @@
 /// The files implements a SYCL-based Python native extension for the
 /// black-scholes benchmark.
 
+#include <CL/sycl.hpp>
 #include <stdlib.h>
-#include <sycl.hpp>
 #include <type_traits>
 
 #ifdef __DO_FLOAT__

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_kernel.hpp
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_kernel.hpp
@@ -1,13 +1,13 @@
 //
 // Copyright 2022 Intel Corp.
 //
-// SPDX - License - Identifier : BSD - 3 - Clause
+// SPDX - License - Identifier : Apache 2.0
 ///
 /// The files implements a SYCL-based Python native extension for the
 /// black-scholes benchmark.
 
-#include <CL/sycl.hpp>
 #include <stdlib.h>
+#include <sycl.hpp>
 #include <type_traits>
 
 #ifdef __DO_FLOAT__

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_sycl.cpp
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_sycl.cpp
@@ -9,10 +9,10 @@
 /// black-scholes benchmark.
 
 #include "_black_scholes_kernel.hpp"
+#include <CL/sycl.hpp>
 #include <dpctl4pybind11.hpp>
 #include <iostream>
 #include <stdlib.h>
-#include <sycl.hpp>
 #include <type_traits>
 #include <vector>
 

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_sycl.cpp
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/black_scholes_sycl/_black_scholes_sycl.cpp
@@ -2,17 +2,17 @@
 //
 // Copyright 2022 Intel Corp.
 //
-// SPDX - License - Identifier : BSD - 3 - Clause
+// SPDX - License - Identifier : Apache 2.0
 ///
 /// \file
 /// The files implements a SYCL-based Python native extension for the
 /// black-scholes benchmark.
 
 #include "_black_scholes_kernel.hpp"
-#include <CL/sycl.hpp>
 #include <dpctl4pybind11.hpp>
 #include <iostream>
 #include <stdlib.h>
+#include <sycl.hpp>
 #include <type_traits>
 #include <vector>
 

--- a/dpbench/benchmarks/pairwise_distance/CMakeLists.txt
+++ b/dpbench/benchmarks/pairwise_distance/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(pairwise_distance_sycl_native_ext)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_dpcpp.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_dpcpp.py
@@ -1,0 +1,7 @@
+# Copyright 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache 2.0
+
+from pairwise_distance_sycl_native_ext import (
+    pairwise_distance_sycl as pairwise_distance,
+)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+set(py_module_name _pairwise_distance_sycl)
+pybind11_add_module(${py_module_name}
+    MODULE
+    pairwise_distance_sycl/_pairwise_distance_sycl.cpp
+)
+target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+
+file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+install(TARGETS ${py_module_name}
+  DESTINATION ${py_module_dest}/pairwise_distance_sycl
+)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/__init__.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache 2.0
+
+from ._pairwise_distance_sycl import pairwise_distance as pairwise_distance_sycl
+
+__all__ = ["pairwise_distance_sycl"]

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2022 Intel Corp.
+//
+// SPDX - License - Identifier : BSD - 3 - Clause
+///
+/// The files implements a SYCL-based Python native extension for the
+/// pairwise_distance benchmark.
+
+#include <CL/sycl.hpp>
+#include <mathimf.h>
+
+using namespace cl::sycl;
+
+#ifdef __DO_FLOAT__
+#define SQRT(x) sqrtf(x)
+#else
+#define SQRT(x) sqrt(x)
+#endif
+
+template <typename FpTy>
+void pairwise_distance_impl(queue Queue,
+                            size_t npoints,
+                            size_t ndims,
+                            const FpTy *p1,
+                            const FpTy *p2,
+                            FpTy *distance_op)
+{
+    Queue.submit([&](handler &h) {
+        h.parallel_for<class PairwiseDistanceKernel>(
+            range<1>{npoints}, [=](id<1> myID) {
+                size_t i = myID[0];
+                for (size_t j = 0; j < npoints; j++) {
+                    FpTy d = 0.;
+                    for (size_t k = 0; k < ndims; k++) {
+                        auto tmp = p1[i * ndims + k] - p2[j * ndims + k];
+                        d += tmp * tmp;
+                    }
+                    if (d != 0.0) {
+                        distance_op[i * npoints + j] = sqrt(d);
+                    }
+                }
+            });
+    });
+
+    Queue.wait();
+}

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
@@ -1,15 +1,15 @@
 //
 // Copyright 2022 Intel Corp.
 //
-// SPDX - License - Identifier : BSD - 3 - Clause
+// SPDX - License - Identifier : Apache 2.0
 ///
 /// The files implements a SYCL-based Python native extension for the
 /// pairwise_distance benchmark.
 
-#include <CL/sycl.hpp>
 #include <mathimf.h>
+#include <sycl.hpp>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 #ifdef __DO_FLOAT__
 #define SQRT(x) sqrtf(x)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
@@ -6,8 +6,8 @@
 /// The files implements a SYCL-based Python native extension for the
 /// pairwise_distance benchmark.
 
+#include <CL/sycl.hpp>
 #include <mathimf.h>
-#include <sycl.hpp>
 
 using namespace sycl;
 

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
@@ -1,0 +1,82 @@
+//==- _pairwise_distance_sycl.cpp - Python native extension of Pairwise_Distance
+//===//
+//
+// Copyright 2022 Intel Corp.
+//
+// SPDX - License - Identifier : BSD - 3 - Clause
+///
+/// \file
+/// The files implements a SYCL-based Python native extension for the
+/// pairwise_distance benchmark.
+
+#include "_pairwise_distance_kernel.hpp"
+#include <CL/sycl.hpp>
+#include <dpctl4pybind11.hpp>
+#include <iostream>
+#include <stdlib.h>
+#include <type_traits>
+#include <vector>
+
+using namespace sycl;
+namespace py = pybind11;
+namespace
+{
+
+template <typename... Args> bool ensure_compatibility(const Args &...args)
+{
+    std::vector<dpctl::tensor::usm_ndarray> arrays = {args...};
+
+    auto arr = arrays.at(0);
+    auto q = arr.get_queue();
+    auto type_flag = arr.get_typenum();
+    auto arr_size = arr.get_size();
+
+    for (auto &arr : arrays) {
+        if (!(arr.get_flags() & (USM_ARRAY_C_CONTIGUOUS))) {
+            std::cerr << "All arrays need to be C contiguous.\n";
+            return false;
+        }
+        if (q != arr.get_queue()) {
+            std::cerr << "All arrays should be in same SYCL queue.\n";
+            return false;
+        }
+        if (arr.get_typenum() != type_flag) {
+            std::cerr << "All arrays should be of same elemental type.\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+void pairwise_distance_sync(dpctl::tensor::usm_ndarray X1,
+                            dpctl::tensor::usm_ndarray X2,
+                            dpctl::tensor::usm_ndarray distance_op)
+{
+    sycl::event res_ev;
+    auto Queue = X1.get_queue();
+    auto ndims = 3;
+    auto npoints = X1.get_size() / ndims;
+
+    if (!ensure_compatibility(X1, X2, distance_op))
+        throw std::runtime_error("Input arrays are not acceptable.");
+
+    if (X1.get_typenum() != UAR_DOUBLE || X2.get_typenum() != UAR_DOUBLE) {
+        throw std::runtime_error("Expected a double precision FP array.");
+    }
+
+    pairwise_distance_impl(Queue, npoints, ndims, X1.get_data<double>(),
+                           X2.get_data<double>(),
+                           distance_op.get_data<double>());
+}
+
+PYBIND11_MODULE(_pairwise_distance_sycl, m)
+{
+    // Import the dpctl extensions
+    import_dpctl();
+
+    m.def("pairwise_distance", &pairwise_distance_sync,
+          "DPC++ implementation of the pairwise_distance formula",
+          py::arg("X1"), py::arg("X1"), py::arg("distance_op"));
+}

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
@@ -10,10 +10,10 @@
 /// pairwise_distance benchmark.
 
 #include "_pairwise_distance_kernel.hpp"
+#include <CL/sycl.hpp>
 #include <dpctl4pybind11.hpp>
 #include <iostream>
 #include <stdlib.h>
-#include <sycl.hpp>
 #include <type_traits>
 #include <vector>
 

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_sycl.cpp
@@ -3,17 +3,17 @@
 //
 // Copyright 2022 Intel Corp.
 //
-// SPDX - License - Identifier : BSD - 3 - Clause
+// SPDX - License - Identifier : Apache 2.0
 ///
 /// \file
 /// The files implements a SYCL-based Python native extension for the
 /// pairwise_distance benchmark.
 
 #include "_pairwise_distance_kernel.hpp"
-#include <CL/sycl.hpp>
 #include <dpctl4pybind11.hpp>
 #include <iostream>
 #include <stdlib.h>
+#include <sycl.hpp>
 #include <type_traits>
 #include <vector>
 

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/setup.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/setup.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache 2.0
+
+import dpctl
+from setuptools import find_packages
+from skbuild import setup
+
+dpctl_include_dir = dpctl.get_include()
+setup(
+    name="pairwise_distance_sycl_native_ext",
+    version="0.0.1",
+    cmake_args=["-DDpctl_INCLUDE_DIRS=" + dpctl_include_dir],
+    description="SYCL implementation for pairwise_distance",
+    author="Intel Scripting",
+    license="Apache 2.0",
+    packages=find_packages(include=["*"]),
+    include_package_data=True,
+)

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -30,6 +30,8 @@ def run_benchmark(
     bdir = "benchmarks/" + bname
     if not pkg_resources.resource_isdir(__name__, bdir):
         return
+    if bname == "__pycache__":
+        return
     bench = None
     try:
         bench = dpbi.Benchmark(bname=bname, bconfig_path=bconfig_path)


### PR DESCRIPTION
- Added native dpcpp version of pairwise_distance.
- Skipped __pycache__ foler in runner, in case foler isn't clean when running.