### PR TITLE
Create a new framework for dpex kernels.

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_dpnp.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_dpnp.py
@@ -4,7 +4,7 @@
 
 import dpnp
 
-invsqrt = lambda x: np.true_divide(1.0, np.sqrt(x))
+invsqrt = lambda x: dpnp.true_divide(1.0, dpnp.sqrt(x))
 
 
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):

--- a/dpbench/configs/framework_info/numba_dpex_kernel.json
+++ b/dpbench/configs/framework_info/numba_dpex_kernel.json
@@ -1,0 +1,10 @@
+{
+    "framework": {
+        "simple_name": "numba_dpex_kernel",
+        "full_name": "numba_dpex_kernel",
+        "prefix": "dpex-kernel",
+        "class": "NumbaDpexKernelFramework",
+        "arch": "cpu",
+        "sycl_device": "cpu"
+    }
+}

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -18,6 +18,7 @@ from .datamodel import store_results
 from .dpcpp_framework import DpcppFramework
 from .framework import Framework
 from .numba_dpex_framework import NumbaDpexFramework
+from .numba_dpex_kernel_framework import NumbaDpexKernelFramework
 from .numba_framework import NumbaFramework
 
 
@@ -558,13 +559,24 @@ class Benchmark(object):
             elif "_python" in bimpl[0]:
                 impl_to_fw_map.update({bimpl[0]: Framework("python")})
             elif "_dpex" in bimpl[0]:
-                try:
-                    fw = NumbaDpexFramework("numba_dpex")
-                    impl_to_fw_map.update({bimpl[0]: fw})
-                except Exception:
-                    logging.exception(
-                        "Framework could not be created for numba_dpex due to:"
-                    )
+                if "dpex_k" in bimpl[0]:
+                    try:
+                        fw = NumbaDpexKernelFramework("numba_dpex_kernel")
+                        impl_to_fw_map.update({bimpl[0]: fw})
+                    except Exception:
+                        logging.exception(
+                            "Framework could not be "
+                            + "created for numba_dpex kernel due to:"
+                        )
+                else:
+                    try:
+                        fw = NumbaDpexFramework("numba_dpex")
+                        impl_to_fw_map.update({bimpl[0]: fw})
+                    except Exception:
+                        logging.exception(
+                            "Framework could not be "
+                            + "created for numba_dpex due to:"
+                        )
             elif "_sycl" in bimpl[0]:
                 try:
                     fw = DpcppFramework("dpcpp")

--- a/dpbench/infrastructure/numba_dpex_framework.py
+++ b/dpbench/infrastructure/numba_dpex_framework.py
@@ -8,12 +8,6 @@ import dpctl
 
 from .framework import Framework
 
-_impl = {
-    "kernel-mode": "k",
-    "numpy-mode": "n",
-    "prange-mode": "p",
-}
-
 
 class NumbaDpexFramework(Framework):
     """A class for reading and processing framework information."""
@@ -28,11 +22,13 @@ class NumbaDpexFramework(Framework):
     def imports(self) -> Dict[str, Any]:
         """Returns a dictionary any modules and methods needed for running
         a benchmark."""
-        import dpctl
 
         return {"dpctl": dpctl}
 
     def execute(self, impl_fn: Callable, input_args: Dict):
-
+        """The njit implementations for numba_dpex require calling the
+        functions inside a dpctl.device_context contextmanager to trigger
+        offload.
+        """
         with dpctl.device_context(self.sycl_device):
             return impl_fn(**input_args)

--- a/dpbench/infrastructure/numba_dpex_kernel_framework.py
+++ b/dpbench/infrastructure/numba_dpex_kernel_framework.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache 2.0
+
+import logging
+from typing import Any, Callable, Dict
+
+import pkg_resources
+
+from .numba_dpex_framework import NumbaDpexFramework
+
+
+class NumbaDpexKernelFramework(NumbaDpexFramework):
+    """A class for reading and processing framework information."""
+
+    def __init__(self, fname: str, fconfig_path: str = None):
+        """Reads framework information.
+        :param fname: The framework name.
+        """
+
+        super().__init__(fname, fconfig_path)
+
+    def imports(self) -> Dict[str, Any]:
+        """Returns a dictionary any modules and methods needed for running
+        a benchmark."""
+        import dpctl
+
+        return {"dpctl": dpctl}
+
+    def copy_to_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying the benchmark arguments to device."""
+
+        def _copy_to_func_impl(ref_array):
+            import dpctl.tensor as dpt
+
+            if ref_array.flags["C_CONTIGUOUS"]:
+                order = "C"
+            elif ref_array.flags["F_CONTIGUOUS"]:
+                order = "F"
+            else:
+                order = "K"
+            return dpt.asarray(
+                obj=ref_array,
+                dtype=ref_array.dtype,
+                device=self.sycl_device,
+                copy=None,
+                usm_type=None,
+                sycl_queue=None,
+                order=order,
+            )
+
+        return _copy_to_func_impl
+
+    def copy_from_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying results back to NumPy (host) from
+        any array created by the framework possibly on
+        a device memory domain."""
+
+        import dpctl.tensor as dpt
+
+        return dpt.asnumpy
+
+    def execute(self, impl_fn: Callable, input_args: Dict):
+        """Numba_dpex kernels support directly passing in
+        dpctl.tensor.usm_ndarray and compute follows data. No need for a
+        device_context.
+
+
+        :param impl_fn: A benchmark implementation.
+        :param input_args: Parameters to be passed to the kernel
+        """
+        return impl_fn(**input_args)
+
+    def version(self) -> str:
+        """Returns the numba-dpex version."""
+
+        try:
+            return pkg_resources.get_distribution("numba_dpex").version
+        except pkg_resources.DistributionNotFound:
+            logging.exception("No version information exists for framework")
+            return "unknown"


### PR DESCRIPTION
Numba dpex kernels support compute follows data and usm_ndarray. The PR introduces a new framework for dpex kernels that follows the dpcpp framework design and moves data copy into the setup section from the execution section of the code. Previously, the execution times for dpex_k was including the data copy times in addition to the execution times.