### PR TITLE
Save dpcpp version during building.

### DIFF
--- a/dpbench/benchmarks/CMakeLists.txt
+++ b/dpbench/benchmarks/CMakeLists.txt
@@ -1,3 +1,13 @@
 add_subdirectory(black_scholes)
 add_subdirectory(pairwise_distance)
 add_subdirectory(l2_norm)
+
+# generate dpcpp version into json
+file(WRITE
+    ${CMAKE_SOURCE_DIR}/dpbench/configs/framework_info/dpcpp_version.json
+    "{\"dpcpp_version\" :"
+    " \""
+    ${CMAKE_CXX_COMPILER_ID}
+    " "
+    ${CMAKE_CXX_COMPILER_VERSION}
+    "\"}")

--- a/dpbench/infrastructure/dpcpp_framework.py
+++ b/dpbench/infrastructure/dpcpp_framework.py
@@ -56,6 +56,13 @@ class DpcppFramework(Framework):
     def version(self) -> str:
         """Returns the framework version."""
         # hack the dpcpp version, need validate dpcpp available first
-        return subprocess.check_output(
-            "dpcpp --version | grep -Po '\(.*?\)' | grep '\.'", shell=True
-        ).decode()
+        import json
+        import pathlib
+
+        parent_folder = pathlib.Path(__file__).parent.absolute()
+        version_file = parent_folder.joinpath(
+            "..", "configs", "framework_info", "dpcpp_version.json"
+        )
+        with open(version_file) as json_file:
+            version = json.load(json_file)["dpcpp_version"]
+        return version


### PR DESCRIPTION
1. dpcpp version used for building is saved in dpcpp_version.json file.
2. dpcpp version saved is included in the package and be used during runtime.