### PR TITLE
Refactor of blackscholes prange and numpy dpex impls

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
@@ -2,47 +2,7 @@
 #
 # SPDX-License-Identifier: Apache 2.0
 
-
-from math import erf
-
-import numba as nb
-from numpy import exp, log, sqrt
-
-
-@nb.vectorize(nopython=True)
-def _nberf(x):
-    return erf(x)
-
-
-# blackscholes implemented using numpy function calls
-@nb.njit(parallel=True, fastmath=True)
-def _black_scholes(price, strike, t, rate, volatility, call, put):
-    mr = -rate
-    sig_sig_two = volatility * volatility * 2
-
-    P = price
-    S = strike
-    T = t
-
-    a = log(P / S)
-    b = T * mr
-
-    z = T * sig_sig_two
-    c = 0.25 * z
-    y = 1.0 / sqrt(z)
-
-    w1 = (a - b + c) * y
-    w2 = (a - b - c) * y
-
-    d1 = 0.5 + 0.5 * _nberf(w1)
-    d2 = 0.5 + 0.5 * _nberf(w2)
-
-    Se = exp(b) * S
-
-    r = P * d1 - Se * d2
-    call[:] = r  # temporary `r` is necessary for faster `put` computation
-    put[:] = r - P + Se
-
+from .black_scholes_numba_np import black_scholes as bs_np
 
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    _black_scholes(price, strike, t, rate, volatility, call, put)
+    bs_np(nopt, price, strike, t, rate, volatility, call, put)

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
@@ -4,5 +4,6 @@
 
 from .black_scholes_numba_np import black_scholes as bs_np
 
+
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     bs_np(nopt, price, strike, t, rate, volatility, call, put)

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
@@ -4,5 +4,6 @@
 
 from .black_scholes_numba_npr import black_scholes as bs_npr
 
+
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     bs_npr(nopt, price, strike, t, rate, volatility, call, put)

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
@@ -2,42 +2,7 @@
 #
 # SPDX-License-Identifier: Apache 2.0
 
-
-from math import erf, exp, log, sqrt
-
-import numba
-
-
-# blackscholes implemented as a parallel loop using numba.prange
-@numba.njit(parallel=True, fastmath=True)
-def _black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    mr = -rate
-    sig_sig_two = volatility * volatility * 2
-
-    for i in numba.prange(nopt):
-        P = price[i]
-        S = strike[i]
-        T = t[i]
-
-        a = log(P / S)
-        b = T * mr
-
-        z = T * sig_sig_two
-        c = 0.25 * z
-        y = 1.0 / sqrt(z)
-
-        w1 = (a - b + c) * y
-        w2 = (a - b - c) * y
-
-        d1 = 0.5 + 0.5 * erf(w1)
-        d2 = 0.5 + 0.5 * erf(w2)
-
-        Se = exp(b) * S
-
-        r = P * d1 - Se * d2
-        call[i] = r
-        put[i] = r - P + Se
-
+from .black_scholes_numba_npr import black_scholes as bs_npr
 
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    _black_scholes(nopt, price, strike, t, rate, volatility, call, put)
+    bs_npr(nopt, price, strike, t, rate, volatility, call, put)


### PR DESCRIPTION
Refactored blackscholes dpex prange and numpy implementations to call the corresponding numba impls (_npr and _npr). This change avoids code duplication in the two impls.