### PR TITLE
Adding pairwise distance numpy based implementations

### DIFF
--- a/dpbench/benchmarks/pairwise_distance/__init__.py
+++ b/dpbench/benchmarks/pairwise_distance/__init__.py
@@ -9,8 +9,14 @@ from .pairwise_distance_numba_dpex_k import (
 from .pairwise_distance_numba_dpex_p import (
     pairwise_distance as pairwise_distance_numba_dpex_p,
 )
+from .pairwise_distance_numba_dpex_n import (
+    pairwise_distance as pairwise_distance_numba_dpex_n,
+)
 from .pairwise_distance_numba_npr import (
     pairwise_distance as pairwise_distance_numba_npr,
+)
+from .pairwise_distance_numba_np import (
+    pairwise_distance as pairwise_distance_numba_np,
 )
 from .pairwise_distance_numpy import (
     pairwise_distance as pairwise_distance_numpy,
@@ -21,7 +27,31 @@ __all__ = [
     "initialize",
     "pairwise_distance_numba_dpex_k",
     "pairwise_distance_numba_dpex_p",
+    "pairwise_distance_numba_dpex_n",
     "pairwise_distance_numba_npr",
+    "pairwise_distance_numba_np",
     "pairwise_distance_numpy",
     "pairwise_distance_sycl",
 ]
+
+"""Pairwise distance computation of 2 n-dim arrays
+
+Input
+---------
+X1: double
+    first n-dim array
+X2: double
+    second n-dim array
+D : double
+    distance matrix
+
+Output
+-------
+d: array
+    pairwise distance
+
+Method
+------
+    D[i,j]+=sqrt((X1[i, k] - X2[j, k])^2)
+    here i,j are 0->number of points, k is 0->dims
+"""

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_n.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_n.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numba as nb
+import numpy as np
+
+@nb.njit(parallel=True, fastmath=True)
+def _pairwise_distance(X1, X2):
+   # Computing the first two terms (X1^2 and X2^2) of the Euclidean distance equation
+   x1 = np.sum(np.square(X1), axis=1)
+   x2 = np.sum(np.square(X2), axis=1)
+
+   # Comnpute third term in equation
+   D = -2 * np.dot(X1, X2.T)
+   x3 = x1.reshape(x1.size, 1)
+   D = D + x3
+   D = D + x2
+
+   # Compute square root for euclidean distance
+   return np.sqrt(D)
+
+def pairwise_distance(X1, X2, D):
+   np.copyto(D, _pairwise_distance(X1, X2))

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_np.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_np.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numba as nb
+import numpy as np
+
+@nb.njit(parallel=True, fastmath=True)
+def _pairwise_distance(X1, X2):
+   # Computing the first two terms (X1^2 and X2^2) of the Euclidean distance equation
+   x1 = np.sum(np.square(X1), axis=1)
+   x2 = np.sum(np.square(X2), axis=1)
+
+   # Comnpute third term in equation
+   D = -2 * np.dot(X1, X2.T)
+   x3 = x1.reshape(x1.size, 1)
+   D = D + x3
+   D = D + x2
+
+   # Compute square root for euclidean distance
+   return np.sqrt(D)
+
+def pairwise_distance(X1, X2, D):
+   np.copyto(D, _pairwise_distance(X1, X2))


### PR DESCRIPTION
Pairwise distance numpy based implementations that worked with numba were a part of `old_main.`  Moving them to the redesigned dpbench. This PR adds the numpy based implementation for numba (numba_np) and numba_dpex(numba_dpex_n).