### PR TITLE
Reset all array args instead only output array args

### DIFF
--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -345,16 +345,9 @@ class BenchmarkRunner:
         self.results.setup_time = t.get_elapsed_time()
 
     def _reset_output_args(self, inputs):
-        try:
-            output_args = self.bench.info["output_args"]
-        except KeyError:
-            logging.info(
-                "No output args to reset as benchmarks has no array output."
-            )
-            return
         array_args = self.bench.info["array_args"]
         for arg in inputs.keys():
-            if arg in output_args and arg in array_args:
+            if arg in array_args:
                 original_data = self.bench.get_data(preset=self.preset)[arg]
                 inputs.update({arg: self.fmwrk.copy_to_func()(original_data)})
 


### PR DESCRIPTION
Only those array args that are output by the workload are reset between repeated executions, which can cause validation errors when certain input args are not reset (eg., in dbscan). This PR makes all array args to be reset.