### PR TITLE
Use native atomics for dpex_k in Github CI.

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -55,6 +55,12 @@ jobs:
         shell: bash -l {0}
         run: |
           export OCL_ICD_FILENAMES=libintelocl.so
+
+          # Make sure numba-dpex is using native atomics in github CI
+          export NUMBA_DPEX_ACTIVATE_ATOMICS_FP_NATIVE=1
+          ls $(dirname $(dirname `which icx`))/bin-llvm || exit 1
+          export NUMBA_DPEX_LLVM_SPIRV_ROOT=$(dirname $(dirname `which icx`))/bin-llvm
+
           LD_PRELOAD="${CONDA_PREFIX}/lib/libmkl_intel_ilp64.so ${CONDA_PREFIX}/lib/libmkl_tbb_thread.so ${CONDA_PREFIX}/lib/libmkl_core.so" python -c "import dpbench; dpbench.run_benchmarks()" || exit 1
           # LD_PRELOAD="${CONDA_PREFIX}/lib/libmkl_intel_ilp64.so ${CONDA_PREFIX}/lib/libmkl_tbb_thread.so ${CONDA_PREFIX}/lib/libmkl_core.so" python -c "import dpbench; dpbench.all_benchmarks_passed_validation(\"dpbench.db\");"
           # res=`                                                                    \


### PR DESCRIPTION
Trying to always use native atomic instructions for numba_dpex_k in Github CI.