### PR TITLE
Ignore the generated dpcpp_version.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 
 # VSCode local files
 .vscode
+
+dpbench/configs/framework_info/dpcpp_version.json


### PR DESCRIPTION
Add the generated `dpbench/configs/framework_info/dpcpp_version.json` file to .gitignore.