### PR TITLE
update the precommit and clang-format versions.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
     -   id: isort
         name: isort (pyi)
         types: [pyi]
--   repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.1.1
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.0
     hooks:
     -   id: clang-format
         args: ["-i"]
+        types_or: [c++, c]


### PR DESCRIPTION
Update the version of clang-format and the pre-commit action we use in the workflow.