### PR TITLE
  Execute each benchmark in a separate sub-process.

### DIFF
--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -5,8 +5,12 @@
 
 import json
 import logging
+import os
 import pathlib
+import tempfile
+from datetime import datetime
 from inspect import getmembers
+from multiprocessing import Manager, Process
 from typing import Any, Dict
 
 import numpy as np
@@ -20,6 +24,116 @@ from .framework import Framework
 from .numba_dpex_framework import NumbaDpexFramework
 from .numba_dpex_kernel_framework import NumbaDpexKernelFramework
 from .numba_framework import NumbaFramework
+
+
+def _reset_output_args(bench, fmwrk, inputs, preset):
+    try:
+        output_args = bench.info["output_args"]
+    except KeyError:
+        logging.info(
+            "No output args to reset as benchmarks has no array output."
+        )
+        return
+    array_args = bench.info["array_args"]
+    for arg in inputs.keys():
+        if arg in output_args and arg in array_args:
+            original_data = bench.get_data(preset=preset)[arg]
+            inputs.update({arg: fmwrk.copy_to_func()(original_data)})
+
+
+def _exec(
+    bench,
+    fmwrk,
+    impl_postfix,
+    preset,
+    timeout,
+    repeat,
+    args,
+    results_dict,
+):
+    input_args = bench.info["input_args"]
+    array_args = bench.info["array_args"]
+    impl_fn = bench.get_impl(impl_postfix)
+    inputs = dict()
+    for arg in input_args:
+        if arg not in array_args:
+            inputs.update({arg: bench.get_data(preset=preset)[arg]})
+        else:
+            inputs.update({arg: args[arg]})
+
+    # Warmup
+    @tout.exit_after(timeout)
+    def warmup(impl_fn, inputs):
+        fmwrk.execute(impl_fn, inputs)
+
+    with timer.timer() as t:
+        try:
+            warmup(impl_fn, inputs)
+        except KeyboardInterrupt:
+            logging.exception(
+                "Benchmark {0} execution failed due to a timeout".format(
+                    bench.bname
+                )
+            )
+            results_dict["error_state"] = -3
+            results_dict["error_msg"] = "Execution failed"
+            return
+        except Exception:
+            logging.exception("Benchmark execution failed at the warmup step.")
+            results_dict["error_state"] = -3
+            results_dict["error_msg"] = "Execution failed"
+            return
+
+    results_dict["warmup_time"] = t.get_elapsed_time()
+    _reset_output_args(bench=bench, fmwrk=fmwrk, inputs=inputs, preset=preset)
+    exec_times = [0] * repeat
+
+    retval = None
+    for i in range(repeat):
+        with timer.timer() as t:
+            retval = fmwrk.execute(impl_fn, inputs)
+        exec_times[i] = t.get_elapsed_time()
+        # Do not reset the output from the last repeat
+        if i < repeat - 1:
+            _reset_output_args(
+                bench=bench, fmwrk=fmwrk, inputs=inputs, preset=preset
+            )
+
+    results_dict["exec_times"] = exec_times
+
+    # Get the output data
+    try:
+        out_args = bench.info["output_args"]
+    except KeyError:
+        out_args = []
+
+    array_args = bench.info["array_args"]
+    output_arrays = dict()
+    with timer.timer() as t:
+        for out_arg in out_args:
+            if out_arg in array_args:
+                output_arrays.update(
+                    {out_arg: fmwrk.copy_from_func()(inputs[out_arg])}
+                )
+    run_datetime = datetime.now().strftime("%m.%d.%Y_%H.%M.%S")
+    out_filename = (
+        bench.bname + "_" + impl_postfix + "_" + preset + "." + run_datetime
+    )
+    out_filename = tempfile.gettempdir() + "/" + out_filename
+    np.savez_compressed(out_filename, **output_arrays)
+    results_dict["outputs"] = out_filename + ".npz"
+    results_dict["teardown_time"] = t.get_elapsed_time()
+
+    # Special case: if the benchmark implementation returns anything, then
+    # add that to the results dict
+
+    if retval:
+        results_dict["return-value"] = retval
+    else:
+        results_dict["return-value"] = None
+
+    results_dict["error_state"] = 0
+    results_dict["error_msg"] = ""
 
 
 def get_supported_implementation_postfixes():
@@ -50,7 +164,7 @@ class BenchmarkResults:
 
     def __init__(self, bench, repeat, impl_postfix, preset):
         """Initialize defaults."""
-        self._fmwrk = None
+        self._fmwrk = bench.get_framework(impl_postfix)
         self._setup_time = -1
         self._warmup_time = -1
         self._teardown_time = -1
@@ -310,12 +424,11 @@ class BenchmarkRunner:
         self.repeat = repeat
         self.timeout = timeout
         self.copied_args = dict()
-        self.results = BenchmarkResults(bench, repeat, impl_postfix, preset)
-
         self.impl_fn = self.bench.get_impl(impl_postfix)
         self.fmwrk = self.bench.get_framework(impl_postfix)
-        self.results.benchmark = self.bench
-        self.results.framework = self.fmwrk
+        self.results = BenchmarkResults(
+            self.bench, self.repeat, impl_postfix, self.preset
+        )
 
         if not self.impl_fn:
             self.results.error_state = -1
@@ -324,12 +437,59 @@ class BenchmarkRunner:
             self.results.error_state = -2
             self.results.error_msg = "No framework"
         else:
-            self.results.error_state = 0
-            self.results.error_msg = ""
             # Run setup step
             self._setup()
             # Execute the benchmark
-            self._exec()
+            with Manager() as manager:
+                results_dict = manager.dict()
+                p = Process(
+                    target=_exec,
+                    args=(
+                        self.bench,
+                        self.fmwrk,
+                        impl_postfix,
+                        preset,
+                        timeout,
+                        repeat,
+                        self.copied_args,
+                        results_dict,
+                    ),
+                )
+                p.start()
+                res = p.join(timeout)
+                if res is None and p.exitcode is None:
+                    logging.error(
+                        "Terminating process due to timeout in the execution "
+                        f"phase of {self.bench.bname} "
+                        f"for the {impl_postfix} implementation"
+                    )
+                    p.kill()
+                    self.results.error_state = results_dict["error_state"]
+                    self.results.error_msg = results_dict["error_msg"]
+                else:
+                    self.results.error_state = results_dict["error_state"]
+                    self.results.error_msg = results_dict["error_msg"]
+                    if self.results.error_state == 0:
+                        self.results.warmup_time = results_dict["warmup_time"]
+                        self.results.exec_times = np.asarray(
+                            results_dict["exec_times"]
+                        )
+                        self.results.teardown_time = results_dict[
+                            "teardown_time"
+                        ]
+
+                        output_npz = results_dict["outputs"]
+                        if output_npz:
+                            npzfile = np.load(output_npz)
+                            for outarr in npzfile.files:
+                                self.results.results.update(
+                                    {outarr: npzfile[outarr]}
+                                )
+                            os.remove(output_npz)
+                        if results_dict["return-value"]:
+                            self.results.results.update(
+                                {"return-value": results_dict["return-value"]}
+                            )
 
     def _setup(self):
         initialized_data = self.bench.get_data(preset=self.preset)
@@ -343,91 +503,6 @@ class BenchmarkRunner:
                 )
 
         self.results.setup_time = t.get_elapsed_time()
-
-    def _reset_output_args(self, inputs):
-        try:
-            output_args = self.bench.info["output_args"]
-        except KeyError:
-            logging.info(
-                "No output args to reset as benchmarks has no array output."
-            )
-            return
-        array_args = self.bench.info["array_args"]
-        for arg in inputs.keys():
-            if arg in output_args and arg in array_args:
-                original_data = self.bench.get_data(preset=self.preset)[arg]
-                inputs.update({arg: self.fmwrk.copy_to_func()(original_data)})
-
-    def _exec(self):
-        input_args = self.bench.info["input_args"]
-        array_args = self.bench.info["array_args"]
-        inputs = dict()
-        for arg in input_args:
-            if arg not in array_args:
-                inputs.update(
-                    {arg: self.bench.get_data(preset=self.preset)[arg]}
-                )
-            else:
-                inputs.update({arg: self.copied_args[arg]})
-
-        # Warmup
-        @tout.exit_after(self.timeout)
-        def warmup(impl_fn, inputs):
-            self.fmwrk.execute(impl_fn, inputs)
-
-        with timer.timer() as t:
-            try:
-                warmup(self.impl_fn, inputs)
-            except KeyboardInterrupt:
-                logging.exception(
-                    "Benchmark {0} execution failed due to a timeout".format(
-                        self.bench.bname
-                    )
-                )
-                self.results.error_state = -3
-                self.results.error_msg = "Execution failed"
-                return
-            except Exception:
-                logging.exception("Benchmark execution failed.")
-                self.results.error_state = -3
-                self.results.error_msg = "Execution failed"
-                return
-
-        self.results.warmup_time = t.get_elapsed_time()
-        self._reset_output_args(inputs=inputs)
-        exec_times = np.empty(self.repeat, dtype=np.float64)
-
-        retval = None
-        for i in range(self.repeat):
-            with timer.timer() as t:
-                retval = self.fmwrk.execute(self.impl_fn, inputs)
-            exec_times[i] = t.get_elapsed_time()
-            # Do not reset the output from the last repeat
-            if i < self.repeat - 1:
-                self._reset_output_args(inputs=inputs)
-
-        self.results.exec_times = exec_times
-
-        # Get the output data
-        try:
-            out_args = self.bench.info["output_args"]
-        except KeyError:
-            out_args = []
-
-        array_args = self.bench.info["array_args"]
-        with timer.timer() as t:
-            for out_arg in out_args:
-                if out_arg in array_args:
-                    self.results.results.update(
-                        {out_arg: self.fmwrk.copy_from_func()(inputs[out_arg])}
-                    )
-        self.results.teardown_time = t.get_elapsed_time()
-
-        # Special case: if the benchmark implementation returns anything, then
-        # add that to the results dict
-
-        if retval:
-            self.results.results.update({"return-value": retval})
 
     def get_results(self):
         return self.results
@@ -786,8 +861,6 @@ class Benchmark(object):
     ):
         results = []
         if not run_datetime:
-            from datetime import datetime
-
             run_datetime = datetime.now().strftime("%m.%d.%Y_%H.%M.%S")
 
         if implementation_postfix:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -51,6 +51,28 @@ def _exec(
     args,
     results_dict,
 ):
+    """Executes a benchmark for a given implementation.
+
+    A helper function to execute a benchmark. The function is called in a
+    separate sub-process by a BenchmarkRunner instance. The ``_exec`` function
+    first runs the benchmark implementation function once as a warmup and then
+    performs the specified number of repetitions. The output results are reset
+    before each repetition and the final output is serialized into a npz
+    (compressed NumPy data file) file.
+
+    All timing results and the path to the serialized results are written to
+    the results_dict input argument that is managed by the calling process.
+
+    Args:
+        bench : A Benchmark object representing the benchmark to be executed.
+        fmwrk : A Framework for which the benchmark is to be executed.
+        impl_postfix : The identifier for the benchmark implementation.
+        preset : A problem size entry defined in the bench_info JSON.
+        timeout : Number of seconds after which the execution is killed.
+        repeat : Number of repetitions of the benchmark execution.
+        args : Input arguments to benchmark implementation function.
+        results_dict : A dictionary where timing and other results are stored.
+    """
     input_args = bench.info["input_args"]
     array_args = bench.info["array_args"]
     impl_fn = bench.get_impl(impl_postfix)

--- a/dpbench/infrastructure/datamodel.py
+++ b/dpbench/infrastructure/datamodel.py
@@ -5,6 +5,8 @@
 import logging
 import sqlite3
 
+from .enums import ErrorCodes, ValidationStatusCodes
+
 _sql_create_results_table = """
 CREATE TABLE IF NOT EXISTS results (
     timestamp integer NOT NULL,
@@ -165,16 +167,20 @@ def store_results(conn, result, run_timestamp):
     data.append("TODO")
     data.append(result.framework_name + " " + result.framework_version)
 
-    if result.error_state == -1:
+    if result.error_state == ErrorCodes.UNIMPLEMENTED:
         error_state_str = "Unimplemented"
-    elif result.error_state == -2:
+    elif result.error_state == ErrorCodes.NO_FRAMEWORK:
         error_state_str = "Framework unavailable"
-    elif result.error_state == -3:
+    elif result.error_state == ErrorCodes.FAILED_EXECUTION:
         error_state_str = "Failed Execution"
-    elif result.error_state == -4:
+    elif result.error_state == ErrorCodes.FAILED_VALIDATION:
         error_state_str = "Failed Validation"
-    else:
+    elif result.error_state == ErrorCodes.EXECUTION_TIMEOUT:
+        error_state_str = "Execution Timeout"
+    elif result.error_state == ErrorCodes.SUCCESS:
         error_state_str = "Success"
+    else:
+        error_state_str = "N/A"
 
     data.append(error_state_str)
     data.append(result.preset)
@@ -188,7 +194,7 @@ def store_results(conn, result, run_timestamp):
     data.append(result.quartile75_exec_time)
     data.append(result.teardown_time)
 
-    if result.validation_state == 0:
+    if result.validation_state == ValidationStatusCodes.SUCCESS:
         validation_str = "Success"
     else:
         validation_str = "Fail"

--- a/dpbench/infrastructure/enums.py
+++ b/dpbench/infrastructure/enums.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache 2.0
+
+from enum import Enum
+
+
+class ErrorCodes(Enum):
+    """An enumeration of the various error codes returned by dpbench"""
+
+    SUCCESS = 0
+    UNIMPLEMENTED = -1
+    NO_FRAMEWORK = -2
+    FAILED_EXECUTION = -3
+    FAILED_VALIDATION = -4
+    EXECUTION_TIMEOUT = -5
+
+
+class ValidationStatusCodes(Enum):
+    """An enumeration of the error codes indicating success/failure of the
+    benchmark validation step
+    """
+
+    SUCCESS = 0
+    FAILURE = -1


### PR DESCRIPTION
The `_exec` member function in the `dpbench.infrastructure.benchmark.BenchmarkRunner` class was converted into a module function. The function executes the actual benchmark implementation. 

After the change, the function is now executed in a separate `Process`. The changes are needed to prevent dpbench to hang if a single benchmark execution hangs or crashes.

Fixes #154 