### PR TITLE
Remove imports from black_scholes

### DIFF
--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -2,36 +2,14 @@
 #
 # SPDX-License-Identifier: Apache 2.0
 
-from .black_scholes_dpnp import black_scholes as black_scholes_dpnp
 from .black_scholes_initialize import initialize
-from .black_scholes_numba_dpex_k import (
-    black_scholes as black_scholes_numba_dpex_k,
-)
-from .black_scholes_numba_dpex_n import (
-    black_scholes as black_scholes_numba_dpex_n,
-)
-from .black_scholes_numba_dpex_p import (
-    black_scholes as black_scholes_numba_dpex_p,
-)
-from .black_scholes_numba_n import black_scholes as black_scholes_numba_n
-from .black_scholes_numba_np import black_scholes as black_scholes_numba_np
-from .black_scholes_numba_npr import black_scholes as black_scholes_numba_npr
 from .black_scholes_numpy import black_scholes as black_scholes_numpy
 from .black_scholes_python import black_scholes as black_scholes_python
-from .black_scholes_sycl_native_ext import black_scholes_sycl
 
 __all__ = [
     "initialize",
-    "black_scholes_dpnp",
-    "black_scholes_numba_dpex_k",
-    "black_scholes_numba_dpex_n",
-    "black_scholes_numba_dpex_p",
-    "black_scholes_numba_n",
-    "black_scholes_numba_np",
-    "black_scholes_numba_npr",
     "black_scholes_numpy",
     "black_scholes_python",
-    "black_scholes_sycl",
 ]
 
 """

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -4,6 +4,10 @@
 
 from .black_scholes_initialize import initialize
 
+# List of all available benchmarks, each element must either a postfix string
+# (in this case specific benchmark module name will be deduced from postfix and
+# benchmark name) or 2-element tuple where first elemtn is potfix and second is
+# module name.
 all_benchmarks = [
     "dpnp",
     "numba_dpex_k",
@@ -14,7 +18,7 @@ all_benchmarks = [
     "numba_npr",
     "numpy",
     "python",
-    "sycl",
+    ("sycl", "black_scholes_sycl_native_ext"),
 ]
 
 __all__ = [

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -18,7 +18,7 @@ all_benchmarks = [
     "numba_npr",
     "numpy",
     "python",
-    ("sycl", "black_scholes_sycl_native_ext"),
+    ("sycl", "black_scholes_sycl_native_ext.black_scholes_sycl"),
 ]
 
 __all__ = [

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: Apache 2.0
 
 from .black_scholes_initialize import initialize
-from .black_scholes_numpy import black_scholes as black_scholes_numpy
-from .black_scholes_python import black_scholes as black_scholes_python
 
 __all__ = [
     "initialize",
-    "black_scholes_numpy",
-    "black_scholes_python",
 ]
 
 """

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -18,7 +18,10 @@ all_benchmarks = [
     "numba_npr",
     "numpy",
     "python",
-    ("sycl", "black_scholes_sycl_native_ext"),
+    (
+        "sycl",
+        "black_scholes_sycl_native_ext.black_scholes_sycl._black_scholes_sycl",
+    ),
 ]
 
 __all__ = [

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -4,8 +4,22 @@
 
 from .black_scholes_initialize import initialize
 
+all_benchmarks = [
+    "dpnp",
+    "numba_dpex_k",
+    "numba_dpex_p",
+    "numba_dpex_n",
+    "numba_n",
+    "numba_np",
+    "numba_npr",
+    "numpy",
+    "python",
+    "sycl",
+]
+
 __all__ = [
     "initialize",
+    "all_benchmarks",
 ]
 
 """

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -6,7 +6,7 @@ from .black_scholes_initialize import initialize
 
 # List of all available benchmarks, each element must either a postfix string
 # (in this case specific benchmark module name will be deduced from postfix and
-# benchmark name) or 2-element tuple where first elemtn is potfix and second is
+# benchmark name) or 2-element tuple where first element is potfix and second is
 # module name.
 all_benchmarks = [
     "dpnp",

--- a/dpbench/benchmarks/black_scholes/__init__.py
+++ b/dpbench/benchmarks/black_scholes/__init__.py
@@ -18,7 +18,7 @@ all_benchmarks = [
     "numba_npr",
     "numpy",
     "python",
-    ("sycl", "black_scholes_sycl_native_ext.black_scholes_sycl"),
+    ("sycl", "black_scholes_sycl_native_ext"),
 ]
 
 __all__ = [

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -824,10 +824,11 @@ class Benchmark(object):
     def _get_updated_fnlist(self, impl_postfix: str, impl_fnlist):
         print("0-0-0-0-0-0 1 ", impl_postfix)
         names = self._get_impl_names()
+        canonical_name = self.bname + "_" + impl_postfix
         if names:
             name = names[impl_postfix]
         else:
-            name = name = self.bname + "_" + impl_postfix
+            name = canonical_name
 
         print("0-0-0-0-0-0 2 ", name)
 
@@ -848,7 +849,7 @@ class Benchmark(object):
         func_names = [self.bname, self.bname + "_" + impl_postfix]
         for func in func_names:
             if hasattr(mod, func):
-                return impl_fnlist + [(name, getattr(mod, func))]
+                return impl_fnlist + [(canonical_name, getattr(mod, func))]
 
         print("0-0-0-0-0-0 4 ", impl_postfix)
         logging.error(

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -850,6 +850,7 @@ class Benchmark(object):
             if hasattr(mod, func):
                 return impl_fnlist + [(name, getattr(mod, func))]
 
+        print("0-0-0-0-0-0 4 ", impl_postfix)
         logging.error(
             "Unable to find benchmark function for " + impl_postfix + " postfix"
         )

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -822,15 +822,12 @@ class Benchmark(object):
         return result
 
     def _get_updated_fnlist(self, impl_postfix: str, impl_fnlist):
-        print("0-0-0-0-0-0 1 ", impl_postfix)
         names = self._get_impl_names()
         canonical_name = self.bname + "_" + impl_postfix
         if names:
             name = names[impl_postfix]
         else:
             name = canonical_name
-
-        print("0-0-0-0-0-0 2 ", name)
 
         for n, _ in impl_fnlist:
             if n == name:
@@ -844,14 +841,11 @@ class Benchmark(object):
             logging.exception("Cannot import " + name)
             return impl_fnlist
 
-        print("0-0-0-0-0-0 3 ", mod, dir(mod))
-
         func_names = [self.bname, self.bname + "_" + impl_postfix]
         for func in func_names:
             if hasattr(mod, func):
                 return impl_fnlist + [(canonical_name, getattr(mod, func))]
 
-        print("0-0-0-0-0-0 4 ", impl_postfix)
         logging.error(
             "Unable to find benchmark function for " + impl_postfix + " postfix"
         )

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -840,7 +840,7 @@ class Benchmark(object):
             logging.exception("Cannot import " + name)
             return impl_fnlist
 
-        print('0-0-0-0-0-0 ', dir(mod))
+        print("0-0-0-0-0-0 ", mod, dir(mod))
 
         func_names = [self.bname, self.bname + "_" + impl_postfix]
         for func in func_names:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -840,6 +840,8 @@ class Benchmark(object):
             logging.exception("Cannot import " + name)
             return impl_fnlist
 
+        print('0-0-0-0-0-0 ', dir(mod))
+
         func_names = [self.bname, self.bname + "_" + impl_postfix]
         for func in func_names:
             if hasattr(mod, func):

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -817,8 +817,6 @@ class Benchmark(object):
             return None
 
         impl_fnlist = self._get_updated_fnlist(impl_postfix, self.impl_fnlist)
-        if impl_fnlist is None:
-            return None
 
         fn = [
             impl[1]

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -469,7 +469,6 @@ class BenchmarkRunner:
             with Manager() as manager:
                 results_dict = manager.dict()
                 p = Process(
-                    # target=tout.exit_after(timeout)(_exec),
                     target=_exec,
                     args=(
                         self.bench,
@@ -488,7 +487,7 @@ class BenchmarkRunner:
                     ),
                 )
                 p.start()
-                res = p.join(timeout * 1.2)
+                res = p.join(timeout)
                 if res is None and p.exitcode is None:
                     logging.error(
                         "Terminating process due to timeout in the execution "

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -938,11 +938,11 @@ class Benchmark(object):
             results.append(result)
 
         else:
+            mod = importlib.import_module("dpbench.benchmarks." + self.bname)
+            bench_list = mod.all_benchmarks
+
             # Run the benchmark for all available implementations
-            for impl in self.get_impl_fnlist():
-                impl_postfix = impl[0][
-                    (len(self.bname) - len(impl[0]) + 1) :  # noqa: E203
-                ]
+            for impl_postfix in bench_list:
                 runner = BenchmarkRunner(
                     bench=self,
                     impl_postfix=impl_postfix,

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -845,6 +845,9 @@ class Benchmark(object):
             if hasattr(mod, func):
                 return impl_fnlist + [(name, getattr(mod, func))]
 
+        logging.error(
+            "Unable find benchmark function for " + impl_postfix + " postfix"
+        )
         return impl_fnlist
 
     def get_impl(self, impl_postfix: str):

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -840,7 +840,12 @@ class Benchmark(object):
             logging.exception("Cannot import " + name)
             return impl_fnlist
 
-        return impl_fnlist + [(name, getattr(mod, self.bname))]
+        func_names = [self.bname, self.bname + "_" + impl_postfix]
+        for func in func_names:
+            if hasattr(mod, func):
+                return impl_fnlist + [(name, getattr(mod, func))]
+
+        return impl_fnlist
 
     def get_impl(self, impl_postfix: str):
         if not impl_postfix:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -826,7 +826,7 @@ class Benchmark(object):
         if names:
             name = names[impl_postfix]
         else:
-            name = name = self.bname + "_" + postfix
+            name = name = self.bname + "_" + impl_postfix
 
         for n, _ in impl_fnlist:
             if n == name:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -796,8 +796,26 @@ class Benchmark(object):
         else:
             return False
 
+    def _get_impl_names(self):
+        mod = importlib.import_module("dpbench.benchmarks." + self.bname)
+        bench_list = mod.all_benchmarks
+
+        result = {}
+        for bench in bench_list:
+            if isinstance(bench, tuple):
+                postfix = bench[0]
+                name = bench[1]
+            else:
+                postfix = bench
+                name = self.bname + "_" + postfix
+
+            result[postfix] = name
+
+        return result
+
     def _get_updated_fnlist(self, impl_postfix: str, impl_fnlist):
-        name = self.bname + "_" + impl_postfix
+        name = self._get_impl_names()[impl_postfix]
+
         for n, _ in impl_fnlist:
             if n == name:
                 return impl_fnlist
@@ -938,8 +956,7 @@ class Benchmark(object):
             results.append(result)
 
         else:
-            mod = importlib.import_module("dpbench.benchmarks." + self.bname)
-            bench_list = mod.all_benchmarks
+            bench_list = self._get_impl_names().keys()
 
             # Run the benchmark for all available implementations
             for impl_postfix in bench_list:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -822,11 +822,14 @@ class Benchmark(object):
         return result
 
     def _get_updated_fnlist(self, impl_postfix: str, impl_fnlist):
+        print("0-0-0-0-0-0 1 ", impl_postfix)
         names = self._get_impl_names()
         if names:
             name = names[impl_postfix]
         else:
             name = name = self.bname + "_" + impl_postfix
+
+        print("0-0-0-0-0-0 2 ", name)
 
         for n, _ in impl_fnlist:
             if n == name:
@@ -840,7 +843,7 @@ class Benchmark(object):
             logging.exception("Cannot import " + name)
             return impl_fnlist
 
-        print("0-0-0-0-0-0 ", mod, dir(mod))
+        print("0-0-0-0-0-0 3 ", mod, dir(mod))
 
         func_names = [self.bname, self.bname + "_" + impl_postfix]
         for func in func_names:

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -846,7 +846,7 @@ class Benchmark(object):
                 return impl_fnlist + [(name, getattr(mod, func))]
 
         logging.error(
-            "Unable find benchmark function for " + impl_postfix + " postfix"
+            "Unable to find benchmark function for " + impl_postfix + " postfix"
         )
         return impl_fnlist
 

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -19,7 +19,7 @@ def _print_results(result):
         + result.benchmark_impl_postfix
         + " ========================"
     )
-    if result.error_state == 0:
+    if result.error_state == dpbi.enums.ErrorCodes.SUCCESS:
         print("implementation:", result.benchmark_impl_postfix)
         print("framework:", result.framework_name)
         print("framework version:", result.framework_version)


### PR DESCRIPTION
* Instead of importing all implementations in `__init__.py`, import them dynamically using `importlib.import_module`
* ~~`numpy` and `python` impls are still needed to be imported explicitly as reference implementation checking code wasn't adapted to new impl~~m done
* `target=tout.exit_after(timeout)(_exec),` was failing on my py 3.9 win machine with `AttributeError: Can't pickle local object 'exit_after.<locals>.outer.<locals>.inner'`, need to investigate
* `os.remove(output_npz)` was failing with `The process cannot access the file because it is being used by another process`