### PR TITLE
Fixing DPBench CI

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Install dpbench dependencies
         shell: bash -l {0}
         run: |
-          conda install -c intel tbb=2021.6.0 dpcpp_linux-64
+          conda install -c intel tbb dpcpp_linux-64
           conda install numpy numba cython cmake ninja scikit-build pandas
-          conda install scipy spirv-tools scikit-learn pybind11
+          conda install scipy scikit-learn pybind11
           conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-          conda install -c dppy/label/dev -c intel dpctl=0.13.0 numba-dpex=0.18.1 dpnp=0.10.1
+          conda install -c intel dpctl numba-dpex dpnp
           conda list
 
       - name: Build dpbench

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.9"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.9"]
+        python: ["3.9", "3.10"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpbench/_version.py"
@@ -23,7 +23,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7
+    rev: v14.0.0
     hooks:
     -   id: clang-format
         args: ["-i"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpbench/_version.py"
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)
@@ -23,7 +23,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.0
+    rev: v15.0.7
     hooks:
     -   id: clang-format
         args: ["-i"]


### PR DESCRIPTION
The CI is broken likely due to incompatible versions of dpbench dependencies. This PR attempts to address the incompatibility.