### PR TITLE
Updates to the versions for code formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     -   id: black
         exclude: "versioneer.py|dpbench/_version.py"
@@ -23,7 +23,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.0
+    rev: v15.0.7
     hooks:
     -   id: clang-format
         args: ["-i"]

--- a/dpbench/benchmarks/dbscan/dbscan_initialize.py
+++ b/dpbench/benchmarks/dbscan/dbscan_initialize.py
@@ -4,7 +4,6 @@
 
 
 def initialize(n_samples, n_features, centers, seed):
-
     from typing import NamedTuple
 
     import numpy as np

--- a/dpbench/benchmarks/dbscan/dbscan_python.py
+++ b/dpbench/benchmarks/dbscan/dbscan_python.py
@@ -7,7 +7,6 @@ from sklearn.cluster import DBSCAN
 
 
 def dbscan(n_samples, n_features, data, eps, min_pts, assignments):
-
     data = np.reshape(data, (n_samples, n_features))
 
     labels = DBSCAN(eps=eps, min_samples=min_pts).fit_predict(data)

--- a/dpbench/benchmarks/gpairs/gpairs_initialize.py
+++ b/dpbench/benchmarks/gpairs/gpairs_initialize.py
@@ -6,14 +6,12 @@ import numpy as np
 
 
 def _generate_rbins(dtype, nbins, rmax, rmin):
-
     rbins = np.logspace(np.log10(rmin), np.log10(rmax), nbins).astype(dtype)
 
     return (rbins**2).astype(dtype)
 
 
 def initialize(nopt, seed, nbins, rmax, rmin):
-
     import numpy.random as default_rng
 
     default_rng.seed(seed)

--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
@@ -27,7 +27,6 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
     rbins_squared,
     result,
 ):
-
     lid0 = numba_dpex.get_local_id(0)
     gr0 = numba_dpex.get_group_id(0)
 

--- a/dpbench/benchmarks/gpairs/gpairs_numba_n.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_n.py
@@ -7,7 +7,6 @@ import numba as nb
 
 @nb.njit(parallel=False, fastmath=True)
 def gpairs(nopt, nbins, x1, y1, z1, w1, x2, y2, z2, w2, rbins, results):
-
     n1 = x1.shape[0]
     n2 = x2.shape[0]
     nbins = rbins.shape[0]

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
@@ -65,7 +65,6 @@ def kmeans_kernel(
     num_points,
     num_centroids,
 ):
-
     copy_arrayC[num_centroids, nb.DEFAULT_LOCAL_SIZE](arrayC, arrayP)
 
     for i in range(niters):
@@ -98,7 +97,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i in range(REPEAT):
         arrayC, arrayCsum, arrayCnumpoint = kmeans_kernel(
             arrayP,

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_n.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_n.py
@@ -9,6 +9,7 @@ REPEAT = 1
 
 __njit = numba.jit(nopython=True, parallel=True, fastmath=True)
 
+
 # determine the euclidean distance from the cluster center to each point
 @__njit
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
@@ -63,7 +64,6 @@ def kmeans_numba(
     num_points,
     num_centroids,
 ):
-
     for i in range(niters):
         groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids)
 
@@ -91,7 +91,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i in range(REPEAT):
         for i1 in range(ncentroids):
             arrayC[i1, 0] = arrayP[i1, 0]

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
@@ -9,6 +9,7 @@ REPEAT = 1
 
 __njit = numba.jit(nopython=True, parallel=True, fastmath=True)
 
+
 # determine the euclidean distance from the cluster center to each point
 @__njit
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
@@ -70,7 +71,6 @@ def kmeans_numba(
     num_points,
     num_centroids,
 ):
-
     for i in range(niters):
         groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids)
 
@@ -98,7 +98,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i in numba.prange(REPEAT):
         copy_arrayC(arrayC, arrayP, ncentroids)
 

--- a/dpbench/benchmarks/kmeans/kmeans_numba_n.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_n.py
@@ -56,7 +56,6 @@ def _kmeans_impl(
     nopt,
     ncentroids,
 ):
-
     for i in range(niters):
         _groupByCluster(arrayP, arrayPcluster, arrayC, nopt, ncentroids)
 
@@ -85,7 +84,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i1 in range(ncentroids):
         arrayC[i1, 0] = arrayP[i1, 0]
         arrayC[i1, 1] = arrayP[i1, 1]

--- a/dpbench/benchmarks/kmeans/kmeans_numba_npr.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_npr.py
@@ -56,7 +56,6 @@ def _kmeans_impl(
     nopt,
     ncentroids,
 ):
-
     for i in range(niters):
         _groupByCluster(arrayP, arrayPcluster, arrayC, nopt, ncentroids)
 
@@ -85,7 +84,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i1 in nb.prange(ncentroids):
         arrayC[i1, 0] = arrayP[i1, 0]
         arrayC[i1, 1] = arrayP[i1, 1]

--- a/dpbench/benchmarks/kmeans/kmeans_numpy.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numpy.py
@@ -86,7 +86,6 @@ def _kmeans_impl(
     num_points,
     num_centroids,
 ):
-
     for i in range(num_iters):
         _groupByCluster(
             arrayP, arrayPcluster, arrayC, num_points, num_centroids
@@ -115,7 +114,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i1 in range(ncentroids):
         arrayC[i1, 0] = arrayP[i1, 0]
         arrayC[i1, 1] = arrayP[i1, 1]

--- a/dpbench/benchmarks/kmeans/kmeans_python.py
+++ b/dpbench/benchmarks/kmeans/kmeans_python.py
@@ -86,7 +86,6 @@ def _kmeans_impl(
     num_points,
     num_centroids,
 ):
-
     for i in range(num_iters):
         _groupByCluster(
             arrayP, arrayPcluster, arrayC, num_points, num_centroids
@@ -115,7 +114,6 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-
     for i1 in range(ncentroids):
         arrayC[i1, 0] = arrayP[i1, 0]
         arrayC[i1, 1] = arrayP[i1, 1]

--- a/dpbench/benchmarks/knn/knn_numba_dpex_p.py
+++ b/dpbench/benchmarks/knn/knn_numba_dpex_p.py
@@ -21,7 +21,6 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-
     for i in numba.prange(test_size):
         queue_neighbors = np.empty(shape=(k, 2))
 

--- a/dpbench/benchmarks/knn/knn_numba_npr.py
+++ b/dpbench/benchmarks/knn/knn_numba_npr.py
@@ -21,7 +21,6 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-
     for i in numba.prange(test_size):
         queue_neighbors = np.empty(shape=(k, 2))
 

--- a/dpbench/benchmarks/knn/knn_sycl_native_ext/knn_sycl/_knn_kernel.hpp
+++ b/dpbench/benchmarks/knn/knn_sycl_native_ext/knn_sycl/_knn_kernel.hpp
@@ -59,7 +59,8 @@ sycl::event knn_impl(sycl::queue q,
                     FpTy new_neighbor_label = queue_neighbors[j].label;
                     size_t index = j;
                     while (index > 0 &&
-                           new_distance < queue_neighbors[index - 1].dist) {
+                           new_distance < queue_neighbors[index - 1].dist)
+                    {
                         queue_neighbors[index] = queue_neighbors[index - 1];
                         index--;
 
@@ -88,7 +89,8 @@ sycl::event knn_impl(sycl::queue q,
                         size_t index = k - 1;
 
                         while (index > 0 &&
-                               new_distance < queue_neighbors[index - 1].dist) {
+                               new_distance < queue_neighbors[index - 1].dist)
+                        {
                             queue_neighbors[index] = queue_neighbors[index - 1];
                             index--;
 

--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
@@ -9,7 +9,6 @@ import numpy
 
 @numba.jit(nopython=True, parallel=True, fastmath=True)
 def rambo(nevts, nout, C1, F1, Q1, output):
-
     for i in numba.prange(nevts):
         for j in range(nout):
             C = 2.0 * C1[i, j] - 1.0

--- a/dpbench/benchmarks/rambo/rambo_numba_n.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_n.py
@@ -8,7 +8,6 @@ import numpy as np
 
 @nb.njit(parallel=False, fastmath=True)
 def rambo(nevts, nout, C1, F1, Q1, output):
-
     for i in range(nevts):
         for j in range(nout):
             C = 2.0 * C1[i, j] - 1.0

--- a/dpbench/benchmarks/rambo/rambo_numba_npr.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_npr.py
@@ -8,7 +8,6 @@ import numpy as np
 
 @nb.njit(parallel=True, fastmath=True)
 def rambo(nevts, nout, C1, F1, Q1, output):
-
     for i in nb.prange(nevts):
         for j in range(nout):
             C = 2.0 * C1[i, j] - 1.0

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -639,7 +639,6 @@ class Benchmark(object):
         impl_to_fw_map = dict()
 
         for bimpl in impl_fnlist:
-
             if "_numba" in bimpl[0] and "_dpex" not in bimpl[0]:
                 impl_to_fw_map.update({bimpl[0]: NumbaFramework("numba")})
             elif "_numpy" in bimpl[0]:
@@ -710,7 +709,6 @@ class Benchmark(object):
             return None
 
     def _validate_results(self, preset, frmwrk, frmwrk_out):
-
         ref_out = self._get_validation_data(preset)
         if not ref_out:
             return False
@@ -766,7 +764,6 @@ class Benchmark(object):
         return self.impl_fnlist
 
     def has_impl(self, impl_postfix: str):
-
         if not impl_postfix:
             return False
 
@@ -781,7 +778,6 @@ class Benchmark(object):
             return False
 
     def get_impl(self, impl_postfix: str):
-
         if not impl_postfix:
             return None
 

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -53,7 +53,6 @@ def list_available_benchmarks():
 
 
 def list_possible_implementations():
-
     parent_folder = pathlib.Path(__file__).parent.absolute()
     impl_postfix_json = parent_folder.joinpath("configs", "impl_postfix.json")
 
@@ -152,7 +151,6 @@ def run_benchmarks(
     impl_postfixes = list_possible_implementations()
 
     for b in list_available_benchmarks():
-
         for impl in impl_postfixes:
             run_benchmark(
                 bname=b,


### PR DESCRIPTION
This PR updates the versions of all formatters - pre-commit-hooks, black, and clang-format. The version update forces changes in source file that do not match the formatting specs. This PR also contains the updates to the source files