### PR TITLE
Change numba_dpex implementations to new decorator

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_n.py
@@ -1,21 +1,15 @@
-# Copyright 2022 Intel Corporation
+# Copyright 2022 Intel Corp.
 #
-# SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp as np
+from numba_dpex import dpjit
+
+invsqrt = lambda x: np.true_divide(1.0, np.sqrt(x))
 
 
-from math import erf
-
-import numba as nb
-from numpy import exp, log, sqrt
-
-
-@nb.vectorize(nopython=True)
-def _nberf(x):
-    return erf(x)
-
-
-@nb.njit(parallel=True, fastmath=True)
-def _black_scholes(price, strike, t, rate, volatility, call, put):
+@dpjit
+def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     mr = -rate
     sig_sig_two = volatility * volatility * 2
 
@@ -23,25 +17,20 @@ def _black_scholes(price, strike, t, rate, volatility, call, put):
     S = strike
     T = t
 
-    a = log(P / S)
+    a = np.log(P / S)
     b = T * mr
 
     z = T * sig_sig_two
     c = 0.25 * z
-    y = 1.0 / sqrt(z)
+    y = invsqrt(z)
 
     w1 = (a - b + c) * y
     w2 = (a - b - c) * y
 
-    d1 = 0.5 + 0.5 * _nberf(w1)
-    d2 = 0.5 + 0.5 * _nberf(w2)
+    d1 = 0.5 + 0.5 * np.erf(w1)
+    d2 = 0.5 + 0.5 * np.erf(w2)
 
-    Se = exp(b) * S
+    Se = np.exp(b) * S
 
-    r = P * d1 - Se * d2
-    call[:] = r  # temporary `r` is necessary for faster `put` computation
-    put[:] = r - P + Se
-
-
-def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    _black_scholes(price, strike, t, rate, volatility, call, put)
+    call[:] = P * d1 - Se * d2
+    put[:] = call - P + Se

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_p.py
@@ -5,16 +5,15 @@
 
 from math import erf, exp, log, sqrt
 
-import numba
+from numba_dpex import dpjit, prange
 
 
-# blackscholes implemented as a parallel loop using numba.prange
-@numba.njit(parallel=True, fastmath=True)
-def _black_scholes(nopt, price, strike, t, rate, volatility, call, put):
+@dpjit
+def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     mr = -rate
     sig_sig_two = volatility * volatility * 2
 
-    for i in numba.prange(nopt):
+    for i in prange(nopt):
         P = price[i]
         S = strike[i]
         T = t[i]
@@ -37,7 +36,3 @@ def _black_scholes(nopt, price, strike, t, rate, volatility, call, put):
         r = P * d1 - Se * d2
         call[i] = r
         put[i] = r - P + Se
-
-
-def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    _black_scholes(nopt, price, strike, t, rate, volatility, call, put)

--- a/dpbench/benchmarks/dbscan/dbscan_numba_dpex_p.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_dpex_p.py
@@ -4,8 +4,9 @@
 
 import numba as nb
 import numpy as np
-from numba import int64, jit, prange
+from numba import int64, jit
 from numba.experimental import jitclass
+from numba_dpex import dpjit, prange
 
 queue_spec = [
     ("capacity", int64),
@@ -57,11 +58,11 @@ UNDEFINED = -2
 DEFAULT_QUEUE_CAPACITY = 10
 
 
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@dpjit
 def get_neighborhood(n, dim, data, eps, ind_lst, sz_lst, assignments):
     block_size = 1
     nblocks = n // block_size + int(n % block_size > 0)
-    for i in nb.prange(nblocks):
+    for i in prange(nblocks):
         start = i * block_size
         stop = n if i + 1 == nblocks else start + block_size
         for j in range(start, stop):

--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_p.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_p.py
@@ -2,17 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba as nb
-import numpy as np
+import dpnp as np
+from numba_dpex import dpjit, prange
+
 
 # This implementation is numba dpex prange version without atomics.
-
-
-@nb.njit(parallel=True, fastmath=True)
+@dpjit
 def count_weighted_pairs_3d_diff_ker(
     n, nbins, x1, y1, z1, w1, x2, y2, z2, w2, rbins_squared, result
 ):
-    for i in nb.prange(n):
+    for i in prange(n):
         px = x1[i]
         py = y1[i]
         pz = z1[i]
@@ -42,9 +41,9 @@ def count_weighted_pairs_3d_diff_ker(
                 result[i, k] += result[i, j]
 
 
-@nb.njit(parallel=True, fastmath=True)
+@dpjit
 def count_weighted_pairs_3d_diff_agg_ker(nbins, result, n):
-    for col_id in nb.prange(nbins):
+    for col_id in prange(nbins):
         for i in range(1, n):
             result[0, col_id] += result[i, col_id]
 

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
@@ -2,19 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba
-import numpy
+import dpnp as np
+from numba_dpex import dpjit, prange
 
 REPEAT = 1
 
-__njit = numba.jit(nopython=True, parallel=True, fastmath=True)
-
 
 # determine the euclidean distance from the cluster center to each point
-@__njit
+@dpjit
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     # parallel for loop
-    for i0 in numba.prange(num_points):
+    for i0 in prange(num_points):
         minor_distance = -1
         for i1 in range(num_centroids):
             dx = arrayP[i0, 0] - arrayC[i1, 0]
@@ -27,12 +25,12 @@ def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
 
 
 # assign points to cluster
-@__njit
+@dpjit
 def calCentroidsSum(
     arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points, num_centroids
 ):
     # parallel for loop
-    for i in numba.prange(num_centroids):
+    for i in prange(num_centroids):
         arrayCsum[i, 0] = 0
         arrayCsum[i, 1] = 0
         arrayCnumpoint[i] = 0
@@ -47,16 +45,16 @@ def calCentroidsSum(
 
 
 # update the centriods array after computation
-@__njit
+@dpjit
 def updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
-    for i in numba.prange(num_centroids):
+    for i in prange(num_centroids):
         arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
         arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@__njit
+@dpjit
 def copy_arrayC(arrayC, arrayP, num_centroids):
-    for i in numba.prange(num_centroids):
+    for i in prange(num_centroids):
         arrayC[i, 0] = arrayP[i, 0]
         arrayC[i, 1] = arrayP[i, 1]
 
@@ -98,7 +96,7 @@ def kmeans(
     nopt,
     ncentroids,
 ):
-    for i in numba.prange(REPEAT):
+    for i in range(REPEAT):
         copy_arrayC(arrayC, arrayP, ncentroids)
 
         arrayC, arrayCsum, arrayCnumpoint = kmeans_numba(

--- a/dpbench/benchmarks/knn/knn_numba_dpex_p.py
+++ b/dpbench/benchmarks/knn/knn_numba_dpex_p.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
-import numba
-import numpy as np
+import dpnp as np
+from numba_dpex import dpjit, prange
 
 
-@numba.njit(parallel=True, fastmath=True)
+@dpjit
 def knn(
     x_train,
     y_train,
@@ -21,7 +19,7 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-    for i in numba.prange(test_size):
+    for i in prange(test_size):
         queue_neighbors = np.empty(shape=(k, 2))
 
         for j in range(k):
@@ -32,7 +30,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             queue_neighbors[j, 0] = dist
             queue_neighbors[j, 1] = y_train[j]
@@ -59,7 +57,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             if dist < queue_neighbors[k - 1][0]:
                 queue_neighbors[k - 1][0] = dist

--- a/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_n.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_n.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba as nb
-import numpy as np
+import dpnp as np
+from numba_dpex import dpjit
 
 
-@nb.njit(parallel=True, fastmath=True)
+@dpjit
 def l2_norm(a, d):
     sq = np.square(a)
     sum = sq.sum(axis=1)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_n.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_n.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba as nb
-import numpy as np
+import dpnp as np
+from numba import dpjit
 
 
-@nb.njit(parallel=True, fastmath=True)
+@dpjit
 def pairwise_distance(X1, X2, D):
     x1 = np.sum(np.square(X1), axis=1)
     x2 = np.sum(np.square(X2), axis=1)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_p.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_p.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba as nb
-import numpy as np
+import dpnp as np
+from numba import dpjit, prange
 
 
-@nb.njit(parallel=True, fastmath=True)
+@dpjit
 def pairwise_distance(X1, X2, D):
     """Naïve pairwise distance impl - take an array representing M points in N
     dimensions, and return the M x M matrix of Euclidean distances
@@ -22,7 +22,7 @@ def pairwise_distance(X1, X2, D):
     O = X1.shape[1]
 
     # Outermost parallel loop over the matrix X1
-    for i in nb.prange(M):
+    for i in prange(M):
         # Loop over the matrix X2
         for j in range(N):
             d = 0.0

--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import numba
-import numpy
+import dpnp as np
+from numba_dpex import dpjit, prange
 
 
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@dpjit
 def rambo(nevts, nout, C1, F1, Q1, output):
-    for i in numba.prange(nevts):
+    for i in prange(nevts):
         for j in range(nout):
             C = 2.0 * C1[i, j] - 1.0
-            S = numpy.sqrt(1 - numpy.square(C))
-            F = 2.0 * numpy.pi * F1[i, j]
-            Q = -numpy.log(Q1[i, j])
+            S = np.sqrt(1 - np.square(C))
+            F = 2.0 * np.pi * F1[i, j]
+            Q = -np.log(Q1[i, j])
 
             output[i, j, 0] = Q
-            output[i, j, 1] = Q * S * numpy.sin(F)
-            output[i, j, 2] = Q * S * numpy.cos(F)
+            output[i, j, 1] = Q * S * np.sin(F)
+            output[i, j, 2] = Q * S * np.cos(F)
             output[i, j, 3] = Q * C

--- a/dpbench/infrastructure/numba_dpex_framework.py
+++ b/dpbench/infrastructure/numba_dpex_framework.py
@@ -4,8 +4,6 @@
 
 from typing import Any, Callable, Dict
 
-import dpctl
-
 from .framework import Framework
 
 
@@ -19,16 +17,34 @@ class NumbaDpexFramework(Framework):
 
         super().__init__(fname, fconfig_path)
 
-    def imports(self) -> Dict[str, Any]:
-        """Returns a dictionary any modules and methods needed for running
-        a benchmark."""
+    def copy_to_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying the benchmark arguments."""
 
-        return {"dpctl": dpctl}
+        def _copy_to_func_impl(ref_array):
+            import dpnp
 
-    def execute(self, impl_fn: Callable, input_args: Dict):
-        """The njit implementations for numba_dpex require calling the
-        functions inside a dpctl.device_context contextmanager to trigger
-        offload.
-        """
-        with dpctl.device_context(self.sycl_device):
-            return impl_fn(**input_args)
+            if ref_array.flags["C_CONTIGUOUS"]:
+                order = "C"
+            elif ref_array.flags["F_CONTIGUOUS"]:
+                order = "F"
+            else:
+                order = "K"
+            return dpnp.asarray(
+                ref_array,
+                dtype=ref_array.dtype,
+                order=order,
+                like=None,
+                device=self.sycl_device,
+                usm_type=None,
+                sycl_queue=None,
+            )
+
+        return _copy_to_func_impl
+
+    def copy_from_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying the benchmark arguments."""
+        import dpnp
+
+        return dpnp.asnumpy


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Changes to numba_dpex implementations of the workloads to use new `@dpjit` decorator instead of numba.njit decorator.
Changed numba_dpex framework to take dpnp arrays as input and removed the invocation of workload kernel using `dpctl.device_context()`.
First commit contains the necessary changes for blackscholes workloads. Future commit to this same PR will make same changes for other workloads. 

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?

Code not tested since functionality is yet not supported in numba_dpex.

- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
