### PR TITLE
Fix _print_results error_state check

### DIFF
--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -2,7 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .benchmark import Benchmark, get_supported_implementation_postfixes
+from .benchmark import (
+    Benchmark,
+    BenchmarkResults,
+    get_supported_implementation_postfixes,
+)
 from .datamodel import (
     create_connection,
     create_results_table,

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -421,7 +421,7 @@ class BenchmarkResults:
         self._results = results
 
     @property
-    def validation_state(self):
+    def validation_state(self) -> ValidationStatusCodes:
         return self._validation_state
 
     @validation_state.setter
@@ -526,7 +526,7 @@ class BenchmarkRunner:
                                 {"return-value": results_dict["return-value"]}
                             )
 
-    def get_results(self):
+    def get_results(self) -> BenchmarkResults:
         return self.results
 
 
@@ -876,7 +876,7 @@ class Benchmark(object):
         validate: bool = True,
         timeout: float = 200.0,
         run_datetime=None,
-    ):
+    ) -> list[BenchmarkResults]:
         results = []
         if not run_datetime:
             run_datetime = datetime.now().strftime("%m.%d.%Y_%H.%M.%S")

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -11,16 +11,19 @@ from datetime import datetime
 
 import dpbench.benchmarks as dp_bms
 import dpbench.infrastructure as dpbi
+from dpbench.infrastructure.enums import ErrorCodes
 
 
 def _print_results(result):
     print(
         "================ implementation "
         + result.benchmark_impl_postfix
-        + " ========================"
+        + " ========================\n"
+        + "implementation:",
+        result.benchmark_impl_postfix,
     )
-    if result.error_state == 0:
-        print("implementation:", result.benchmark_impl_postfix)
+
+    if result.error_state == ErrorCodes.SUCCESS:
         print("framework:", result.framework_name)
         print("framework version:", result.framework_version)
         print("setup time:", result.setup_time)
@@ -33,7 +36,6 @@ def _print_results(result):
         print("preset:", result.preset)
         print("validated:", result.validation_state)
     else:
-        print("implementation:", result.benchmark_impl_postfix)
         print("error states:", result.error_state)
         print("error msg:", result.error_msg)
 

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -14,7 +14,7 @@ import dpbench.infrastructure as dpbi
 from dpbench.infrastructure.enums import ErrorCodes
 
 
-def _print_results(result):
+def _print_results(result: dpbi.BenchmarkResults):
     print(
         "================ implementation "
         + result.benchmark_impl_postfix
@@ -34,7 +34,7 @@ def _print_results(result):
         print("median execution times:", result.median_exec_time)
         print("repeats:", result.num_repeats)
         print("preset:", result.preset)
-        print("validated:", result.validation_state)
+        print("validated:", result.validation_state.name)
     else:
         print("error states:", result.error_state)
         print("error msg:", result.error_msg)


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer? n/a
- [ ] Have you tested your changes locally for CPU and GPU devices? n/a
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft? n/a

Running example causes to fake error output trigger:
```
python -c "import dpbench; dpbench.run_benchmark(\"black_scholes\")"

================ Benchmark black_scholes ========================

================ implementation dpnp ========================
implementation: dpnp
error states: ErrorCodes.SUCCESS
error msg:
...
```

After this fix:
```
python -c "import dpbench; dpbench.run_benchmark(\"black_scholes\")"

================ Benchmark black_scholes ========================

================ implementation dpnp ========================
implementation: dpnp
framework: dpnp
framework version: 0.11.0
setup time: <number>
warmup time: <number>
teardown time: <number>
max execution times: <number>
min execution times: <number>
median execution times: <number>
repeats: 10
preset: S
validated: SUCCESS
...
```

