### PR TITLE
Reverting CI to pull packages from dppy/label/dev

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.9", "3.10"]
+        python: ["3.10"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.9"]
+        python: ["3.9", "3.10"]
 
     steps:
       - name: Cancel Previous Runs
@@ -43,7 +43,7 @@ jobs:
           conda install numpy numba cython cmake ninja scikit-build pandas
           conda install scipy scikit-learn pybind11
           conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-          conda install -c dppy/label/dev dpctl numba-dpex dpnp
+          conda install -c dppy/label/dev -c intel -c main dpctl numba-dpex dpnp
           conda list
 
       - name: Build dpbench

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.11"]
+        python: ["3.9"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -43,7 +43,7 @@ jobs:
           conda install numpy numba cython cmake ninja scikit-build pandas
           conda install scipy scikit-learn pybind11
           conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-          conda install -c intel dpctl numba-dpex dpnp
+          conda install -c dppy/label/dev dpctl numba-dpex dpnp
           conda list
 
       - name: Build dpbench

--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.11"]
 
     steps:
       - name: Cancel Previous Runs

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         $ conda install scipy scikit-learn pybind11
         # do not miss the quotes!
         $ conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-        $ conda install -c intel dpctl numba-dpex dpnp
+        $ conda install -c dppy/label/dev dpctl numba-dpex dpnp
 
 2. Build and run DPBench
     - To build:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         $ conda install scipy scikit-learn pybind11
         # do not miss the quotes!
         $ conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-        $ conda install -c dppy/label/dev dpctl numba-dpex dpnp
+        $ conda install -c dppy/label/dev -c intel -c main dpctl numba-dpex dpnp
 
 2. Build and run DPBench
     - To build:


### PR DESCRIPTION
PR reverts back to using dppy/label/dev channel to pull dpep packages. Also updated Readme to do the same.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
