### PR TITLE
Add input size

### DIFF
--- a/dpbench/infrastructure/datamodel.py
+++ b/dpbench/infrastructure/datamodel.py
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS results (
     framework_version text NOT NULL,
     error_state text NOT NULL,
     problem_preset text,
+    input_size integer,
     setup_time real,
     warmup_time real,
     repeats text,
@@ -39,6 +40,7 @@ INSERT INTO results(
     framework_version,
     error_state,
     problem_preset,
+    input_size,
     repeats,
     setup_time,
     warmup_time,
@@ -49,7 +51,7 @@ INSERT INTO results(
     quartile75_exec_time,
     teardown_time,
     validated
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 """
 
 
@@ -87,6 +89,7 @@ def create_results_table(conn):
         )
 
 
+# TODO: refactor for proper typing. Current typing for 'result' produce import loop error
 def store_results(conn, result, run_timestamp):
     data = []
 
@@ -113,6 +116,7 @@ def store_results(conn, result, run_timestamp):
 
     data.append(error_state_str)
     data.append(result.preset)
+    data.append(result.input_size)
     data.append(str(result.num_repeats))
     data.append(result.setup_time)
     data.append(result.warmup_time)

--- a/dpbench/infrastructure/reporter.py
+++ b/dpbench/infrastructure/reporter.py
@@ -19,7 +19,14 @@ _sql_latest_implementation_summary = """
 SELECT
     MAX(timestamp) as As_of,
     benchmark,
-    problem_preset as problem_size,
+    problem_preset,
+    CASE
+        WHEN MAX(input_size) < 1024 THEN MAX(input_size) || 'B'
+        WHEN MAX(input_size) >=  1024 AND MAX(input_size) < (1024 * 1024) THEN (MAX(input_size) / 1024) || 'KB'
+        WHEN MAX(input_size) >= (1024 * 1024)  AND MAX(input_size) < (1024 * 1024 * 1024) THEN (MAX(input_size) / (1024 * 1024)) || 'MB'
+        WHEN MAX(input_size) >= (1024 * 1024 * 1024) AND MAX(input_size) < (1024 * 1024 * 1024 *1024) THEN (MAX(input_size) / (1024 * 1024 * 1024)) || 'GB'
+        WHEN MAX(input_size) >= (1024 * 1024 * 1024 * 1024) THEN (MAX(input_size) / (1024 * 1024 * 1024 * 1024)) || 'TB'
+    END AS input_size,
     MAX(
         CASE
             WHEN implementation == "numba_dpex_k" THEN error_state


### PR DESCRIPTION
```
Summary of current implementation
=================================
                 As_of          benchmark problem_preset input_size      numba_dpex_k      numba_dpex_p      numba_dpex_n              dpnp          numpy         python        numba_n       numba_np      numba_npr          dpcpp
0  03.29.2023_11.59.56      black_scholes              S       15MB           Success           Success           Success           Success        Success        Success        Success        Success        Success        Success
1  03.29.2023_11.59.56             dbscan              S       88KB  Failed Execution           Success     Unimplemented     Unimplemented  Unimplemented        Success        Success  Unimplemented        Success  Unimplemented
2  03.29.2023_11.59.56             gpairs              S        4KB           Success           Success     Unimplemented  Failed Execution        Success  Unimplemented        Success  Unimplemented        Success        Success
3  03.29.2023_11.59.56             kmeans              S       78KB           Success           Success           Success     Unimplemented        Success        Success        Success  Unimplemented        Success  Unimplemented
4  03.29.2023_11.59.56                knn              S      296KB           Success  Failed Execution     Unimplemented     Unimplemented  Unimplemented        Success  Unimplemented  Unimplemented        Success        Success
5  03.29.2023_11.59.56            l2_norm              S        1MB           Success     Unimplemented  Failed Execution           Success        Success  Unimplemented        Success        Success  Unimplemented        Success
6  03.29.2023_11.59.56  pairwise_distance              S        8MB           Success           Success  Failed Execution  Failed Execution        Success  Unimplemented  Unimplemented        Success        Success        Success
7  03.29.2023_11.59.56              rambo              S        7MB           Success           Success     Unimplemented     Unimplemented        Success  Unimplemented        Success  Unimplemented        Success        Success
```

For better reporting it adds input arrays size to the report. Output arrays was not added, since they usually intersects with input arrays.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer? n/a
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?

Closes #144 