### PR TITLE
Creating consistent imports across all workloads

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_dpnp.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_dpnp.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpnp
+import dpnp as np
 
-invsqrt = lambda x: dpnp.true_divide(1.0, dpnp.sqrt(x))
+invsqrt = lambda x: np.true_divide(1.0, np.sqrt(x))
 
 
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
@@ -15,7 +15,7 @@ def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     S = strike
     T = t
 
-    a = dpnp.log(P / S)
+    a = np.log(P / S)
     b = T * mr
 
     z = T * sig_sig_two
@@ -25,10 +25,10 @@ def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
     w1 = (a - b + c) * y
     w2 = (a - b - c) * y
 
-    d1 = 0.5 + 0.5 * dpnp.erf(w1)
-    d2 = 0.5 + 0.5 * dpnp.erf(w2)
+    d1 = 0.5 + 0.5 * np.erf(w1)
+    d2 = 0.5 + 0.5 * np.erf(w2)
 
-    Se = dpnp.exp(b) * S
+    Se = np.exp(b) * S
 
     call[:] = P * d1 - Se * d2
     put[:] = call - P + Se

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_k.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_k.py
@@ -5,15 +5,15 @@
 
 from math import erf, exp, log, sqrt
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 
 
-@nbdx.kernel
+@dpex.kernel
 def _black_scholes_kernel(nopt, price, strike, t, rate, volatility, call, put):
     mr = -rate
     sig_sig_two = volatility * volatility * 2
 
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
 
     P = price[i]
     S = strike[i]

--- a/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_k.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_numba_dpex_k.py
@@ -5,20 +5,15 @@
 
 from math import erf, exp, log, sqrt
 
-import numba_dpex as nb
+import numba_dpex as nbdx
 
 
-@nb.kernel(
-    access_types={
-        "read_only": ["price", "strike", "t"],
-        "write_only": ["call", "put"],
-    }
-)
+@nbdx.kernel
 def _black_scholes_kernel(nopt, price, strike, t, rate, volatility, call, put):
     mr = -rate
     sig_sig_two = volatility * volatility * 2
 
-    i = nb.get_global_id(0)
+    i = nbdx.get_global_id(0)
 
     P = price[i]
     S = strike[i]
@@ -45,6 +40,6 @@ def _black_scholes_kernel(nopt, price, strike, t, rate, volatility, call, put):
 
 
 def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
-    _black_scholes_kernel[nopt, nb.DEFAULT_LOCAL_SIZE](
+    _black_scholes_kernel[nopt,](
         nopt, price, strike, t, rate, volatility, call, put
     )

--- a/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
@@ -5,7 +5,7 @@
 
 import dpctl.tensor as dpt
 import numba as nb
-import numba_dpex as nbdx
+import numba_dpex as dpex
 import numpy as np
 
 NOISE = -1
@@ -50,9 +50,9 @@ def _queue_empty(head, tail):
     return head == tail
 
 
-@nbdx.kernel
+@dpex.kernel
 def get_neighborhood(n, dim, data, eps, ind_lst, sz_lst, block_size, nblocks):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
 
     start = i * block_size
     stop = n if i + 1 == nblocks else start + block_size

--- a/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
@@ -5,7 +5,7 @@
 
 import dpctl.tensor as dpt
 import numba as nb
-import numba_dpex as nbd
+import numba_dpex as nbdx
 import numpy as np
 
 NOISE = -1
@@ -50,9 +50,9 @@ def _queue_empty(head, tail):
     return head == tail
 
 
-@nbd.kernel
+@nbdx.kernel
 def get_neighborhood(n, dim, data, eps, ind_lst, sz_lst, block_size, nblocks):
-    i = nbd.get_global_id(0)
+    i = nbdx.get_global_id(0)
 
     start = i * block_size
     stop = n if i + 1 == nblocks else start + block_size
@@ -144,7 +144,7 @@ def dbscan(n_samples, n_features, data, eps, min_pts):
         sycl_queue=None,
     )
 
-    get_neighborhood[n_samples, nbd.DEFAULT_LOCAL_SIZE](
+    get_neighborhood[n_samples,](
         n_samples,
         n_features,
         data,

--- a/dpbench/benchmarks/gpairs/gpairs_dpnp.py
+++ b/dpbench/benchmarks/gpairs/gpairs_dpnp.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpnp
+import dpnp as np
 
 
 def _gpairs_impl(x1, y1, z1, w1, x2, y2, z2, w2, rbins):
     dm = (
-        dpnp.square(x2 - x1[:, None])
-        + dpnp.square(y2 - y1[:, None])
-        + dpnp.square(z2 - z1[:, None])
+        np.square(x2 - x1[:, None])
+        + np.square(y2 - y1[:, None])
+        + np.square(z2 - z1[:, None])
     )
-    return dpnp.array(
-        [dpnp.outer(w1, w2)[dm <= rbins[k]].sum() for k in range(len(rbins))]
+    return np.array(
+        [np.outer(w1, w2)[dm <= rbins[k]].sum() for k in range(len(rbins))]
     )
 
 

--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
@@ -4,13 +4,13 @@
 
 import math
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 import numpy as np
 
 # This implementation is numba dpex kernel version with atomics.
 
 
-@nbdx.kernel
+@dpex.kernel
 def count_weighted_pairs_3d_intel_no_slm_ker(
     n,
     nbins,
@@ -27,20 +27,20 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
     rbins_squared,
     result,
 ):
-    lid0 = nbdx.get_local_id(0)
-    gr0 = nbdx.get_group_id(0)
+    lid0 = dpex.get_local_id(0)
+    gr0 = dpex.get_group_id(0)
 
-    lid1 = nbdx.get_local_id(1)
-    gr1 = nbdx.get_group_id(1)
+    lid1 = dpex.get_local_id(1)
+    gr1 = dpex.get_group_id(1)
 
-    lws0 = nbdx.get_local_size(0)
-    lws1 = nbdx.get_local_size(1)
+    lws0 = dpex.get_local_size(0)
+    lws1 = dpex.get_local_size(1)
 
     n_wi = 20
 
-    dsq_mat = nbdx.private.array(shape=(20 * 20), dtype=np.float32)
-    w0_vec = nbdx.private.array(shape=(20), dtype=np.float32)
-    w1_vec = nbdx.private.array(shape=(20), dtype=np.float32)
+    dsq_mat = dpex.private.array(shape=(20 * 20), dtype=np.float32)
+    w0_vec = dpex.private.array(shape=(20), dtype=np.float32)
+    w1_vec = dpex.private.array(shape=(20), dtype=np.float32)
 
     offset0 = gr0 * n_wi * lws0 + lid0
     offset1 = gr1 * n_wi * lws1 + lid1
@@ -80,7 +80,7 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
 
     # update slm_hist. Use work-item private buffer of 16 tfloat elements
     for k in range(0, slm_hist_size, private_hist_size):
-        private_hist = nbdx.private.array(shape=(16), dtype=np.float32)
+        private_hist = dpex.private.array(shape=(16), dtype=np.float32)
         for p in range(private_hist_size):
             private_hist[p] = 0.0
 
@@ -109,7 +109,7 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
 
         pk = k
         for p in range(private_hist_size):
-            nbdx.atomic.add(result, pk, private_hist[p])
+            dpex.atomic.add(result, pk, private_hist[p])
             pk += 1
 
 

--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
@@ -4,13 +4,13 @@
 
 import math
 
-import numba_dpex
+import numba_dpex as nbdx
 import numpy as np
 
 # This implementation is numba dpex kernel version with atomics.
 
 
-@numba_dpex.kernel
+@nbdx.kernel
 def count_weighted_pairs_3d_intel_no_slm_ker(
     n,
     nbins,
@@ -27,20 +27,20 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
     rbins_squared,
     result,
 ):
-    lid0 = numba_dpex.get_local_id(0)
-    gr0 = numba_dpex.get_group_id(0)
+    lid0 = nbdx.get_local_id(0)
+    gr0 = nbdx.get_group_id(0)
 
-    lid1 = numba_dpex.get_local_id(1)
-    gr1 = numba_dpex.get_group_id(1)
+    lid1 = nbdx.get_local_id(1)
+    gr1 = nbdx.get_group_id(1)
 
-    lws0 = numba_dpex.get_local_size(0)
-    lws1 = numba_dpex.get_local_size(1)
+    lws0 = nbdx.get_local_size(0)
+    lws1 = nbdx.get_local_size(1)
 
     n_wi = 20
 
-    dsq_mat = numba_dpex.private.array(shape=(20 * 20), dtype=np.float32)
-    w0_vec = numba_dpex.private.array(shape=(20), dtype=np.float32)
-    w1_vec = numba_dpex.private.array(shape=(20), dtype=np.float32)
+    dsq_mat = nbdx.private.array(shape=(20 * 20), dtype=np.float32)
+    w0_vec = nbdx.private.array(shape=(20), dtype=np.float32)
+    w1_vec = nbdx.private.array(shape=(20), dtype=np.float32)
 
     offset0 = gr0 * n_wi * lws0 + lid0
     offset1 = gr1 * n_wi * lws1 + lid1
@@ -80,7 +80,7 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
 
     # update slm_hist. Use work-item private buffer of 16 tfloat elements
     for k in range(0, slm_hist_size, private_hist_size):
-        private_hist = numba_dpex.private.array(shape=(16), dtype=np.float32)
+        private_hist = nbdx.private.array(shape=(16), dtype=np.float32)
         for p in range(private_hist_size):
             private_hist[p] = 0.0
 
@@ -109,7 +109,7 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
 
         pk = k
         for p in range(private_hist_size):
-            numba_dpex.atomic.add(result, pk, private_hist[p])
+            nbdx.atomic.add(result, pk, private_hist[p])
             pk += 1
 
 

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
@@ -1,56 +1,53 @@
 # Copyright 2022 Intel Corp.
 #
 # SPDX-License-Identifier: Apache-2.0
-import numba_dpex as nb
-import numpy
-from numba_dpex import atomic
 
-REPEAT = 1
+from math import sqrt
 
-atomic_add = atomic.add
+import numba_dpex as nbdx
 
 
-@nb.kernel
+@nbdx.kernel
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
-    idx = nb.get_global_id(0)
+    idx = nbdx.get_global_id(0)
     # if idx < num_points: # why it was removed??
     minor_distance = -1
     for i in range(num_centroids):
         dx = arrayP[idx, 0] - arrayC[i, 0]
         dy = arrayP[idx, 1] - arrayC[i, 1]
-        my_distance = numpy.sqrt(dx * dx + dy * dy)
+        my_distance = sqrt(dx * dx + dy * dy)
         if minor_distance > my_distance or minor_distance == -1:
             minor_distance = my_distance
             arrayPcluster[idx] = i
 
 
-@nb.kernel
+@nbdx.kernel
 def calCentroidsSum1(arrayCsum, arrayCnumpoint):
-    i = nb.get_global_id(0)
+    i = nbdx.get_global_id(0)
     arrayCsum[i, 0] = 0
     arrayCsum[i, 1] = 0
     arrayCnumpoint[i] = 0
 
 
-@nb.kernel
+@nbdx.kernel
 def calCentroidsSum2(arrayP, arrayPcluster, arrayCsum, arrayCnumpoint):
-    i = nb.get_global_id(0)
+    i = nbdx.get_global_id(0)
     ci = arrayPcluster[i]
-    atomic_add(arrayCsum, (ci, 0), arrayP[i, 0])
-    atomic_add(arrayCsum, (ci, 1), arrayP[i, 1])
-    atomic_add(arrayCnumpoint, ci, 1)
+    nbdx.atomic.add(arrayCsum, (ci, 0), arrayP[i, 0])
+    nbdx.atomic.add(arrayCsum, (ci, 1), arrayP[i, 1])
+    nbdx.atomic.add(arrayCnumpoint, ci, 1)
 
 
-@nb.kernel
+@nbdx.kernel
 def updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
-    i = nb.get_global_id(0)
+    i = nbdx.get_global_id(0)
     arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
     arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@nb.kernel
+@nbdx.kernel
 def copy_arrayC(arrayC, arrayP):
-    i = nb.get_global_id(0)
+    i = nbdx.get_global_id(0)
     arrayC[i, 0] = arrayP[i, 0]
     arrayC[i, 1] = arrayP[i, 1]
 
@@ -65,22 +62,20 @@ def kmeans_kernel(
     num_points,
     num_centroids,
 ):
-    copy_arrayC[num_centroids, nb.DEFAULT_LOCAL_SIZE](arrayC, arrayP)
+    copy_arrayC[num_centroids,](arrayC, arrayP)
 
     for i in range(niters):
-        groupByCluster[num_points, nb.DEFAULT_LOCAL_SIZE](
+        groupByCluster[num_points,](
             arrayP, arrayPcluster, arrayC, num_points, num_centroids
         )
 
-        calCentroidsSum1[num_centroids, nb.DEFAULT_LOCAL_SIZE](
-            arrayCsum, arrayCnumpoint
-        )
+        calCentroidsSum1[num_centroids,](arrayCsum, arrayCnumpoint)
 
-        calCentroidsSum2[num_points, nb.DEFAULT_LOCAL_SIZE](
+        calCentroidsSum2[num_points,](
             arrayP, arrayPcluster, arrayCsum, arrayCnumpoint
         )
 
-        updateCentroids[num_centroids, nb.DEFAULT_LOCAL_SIZE](
+        updateCentroids[num_centroids,](
             arrayC, arrayCsum, arrayCnumpoint, num_centroids
         )
 
@@ -98,14 +93,13 @@ def kmeans(
     ndims,
     ncentroids,
 ):
-    for i in range(REPEAT):
-        arrayC, arrayCsum, arrayCnumpoint = kmeans_kernel(
-            arrayP,
-            arrayPclusters,
-            arrayC,
-            arrayCsum,
-            arrayCnumpoint,
-            niters,
-            npoints,
-            ncentroids,
-        )
+    arrayC, arrayCsum, arrayCnumpoint = kmeans_kernel(
+        arrayP,
+        arrayPclusters,
+        arrayC,
+        arrayCsum,
+        arrayCnumpoint,
+        niters,
+        npoints,
+        ncentroids,
+    )

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
@@ -4,12 +4,12 @@
 
 from math import sqrt
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 
 
-@nbdx.kernel
+@dpex.kernel
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
-    idx = nbdx.get_global_id(0)
+    idx = dpex.get_global_id(0)
     # if idx < num_points: # why it was removed??
     minor_distance = -1
     for i in range(num_centroids):
@@ -21,33 +21,33 @@ def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
             arrayPcluster[idx] = i
 
 
-@nbdx.kernel
+@dpex.kernel
 def calCentroidsSum1(arrayCsum, arrayCnumpoint):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     arrayCsum[i, 0] = 0
     arrayCsum[i, 1] = 0
     arrayCnumpoint[i] = 0
 
 
-@nbdx.kernel
+@dpex.kernel
 def calCentroidsSum2(arrayP, arrayPcluster, arrayCsum, arrayCnumpoint):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     ci = arrayPcluster[i]
-    nbdx.atomic.add(arrayCsum, (ci, 0), arrayP[i, 0])
-    nbdx.atomic.add(arrayCsum, (ci, 1), arrayP[i, 1])
-    nbdx.atomic.add(arrayCnumpoint, ci, 1)
+    dpex.atomic.add(arrayCsum, (ci, 0), arrayP[i, 0])
+    dpex.atomic.add(arrayCsum, (ci, 1), arrayP[i, 1])
+    dpex.atomic.add(arrayCnumpoint, ci, 1)
 
 
-@nbdx.kernel
+@dpex.kernel
 def updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
     arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@nbdx.kernel
+@dpex.kernel
 def copy_arrayC(arrayC, arrayP):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     arrayC[i, 0] = arrayP[i, 0]
     arrayC[i, 1] = arrayP[i, 1]
 

--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_p.py
@@ -2,24 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba
-import numpy
-
-REPEAT = 1
-
-__njit = numba.jit(nopython=True, parallel=True, fastmath=True)
+import numba as nb
+import numpy as np
 
 
 # determine the euclidean distance from the cluster center to each point
-@__njit
+@nb.njit(parallel=True, fastmath=True)
 def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     # parallel for loop
-    for i0 in numba.prange(num_points):
+    for i0 in nb.prange(num_points):
         minor_distance = -1
         for i1 in range(num_centroids):
             dx = arrayP[i0, 0] - arrayC[i1, 0]
             dy = arrayP[i0, 1] - arrayC[i1, 1]
-            my_distance = numpy.sqrt(dx * dx + dy * dy)
+            my_distance = np.sqrt(dx * dx + dy * dy)
             if minor_distance > my_distance or minor_distance == -1:
                 minor_distance = my_distance
                 arrayPcluster[i0] = i1
@@ -27,12 +23,12 @@ def groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
 
 
 # assign points to cluster
-@__njit
+@nb.njit(parallel=True, fastmath=True)
 def calCentroidsSum(
     arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points, num_centroids
 ):
     # parallel for loop
-    for i in numba.prange(num_centroids):
+    for i in nb.prange(num_centroids):
         arrayCsum[i, 0] = 0
         arrayCsum[i, 1] = 0
         arrayCnumpoint[i] = 0
@@ -47,16 +43,16 @@ def calCentroidsSum(
 
 
 # update the centriods array after computation
-@__njit
+@nb.njit(parallel=True, fastmath=True)
 def updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
-    for i in numba.prange(num_centroids):
+    for i in nb.prange(num_centroids):
         arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
         arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@__njit
+@nb.njit(parallel=True, fastmath=True)
 def copy_arrayC(arrayC, arrayP, num_centroids):
-    for i in numba.prange(num_centroids):
+    for i in nb.prange(num_centroids):
         arrayC[i, 0] = arrayP[i, 0]
         arrayC[i, 1] = arrayP[i, 1]
 
@@ -99,16 +95,15 @@ def kmeans(
     ndims,
     ncentroids,
 ):
-    for i in numba.prange(REPEAT):
-        copy_arrayC(arrayC, arrayP, ncentroids)
+    copy_arrayC(arrayC, arrayP, ncentroids)
 
-        arrayC, arrayCsum, arrayCnumpoint = kmeans_numba(
-            arrayP,
-            arrayPclusters,
-            arrayC,
-            arrayCsum,
-            arrayCnumpoint,
-            niters,
-            npoints,
-            ncentroids,
-        )
+    arrayC, arrayCsum, arrayCnumpoint = kmeans_numba(
+        arrayP,
+        arrayPclusters,
+        arrayC,
+        arrayCsum,
+        arrayCnumpoint,
+        niters,
+        npoints,
+        ncentroids,
+    )

--- a/dpbench/benchmarks/kmeans/kmeans_numba_n.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_n.py
@@ -3,24 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numba as nb
-import numpy
+import numpy as np
 
 
-@nb.jit(nopython=True, parallel=False, fastmath=True)
+@nb.njit(parallel=False, fastmath=True)
 def _groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     for i0 in nb.prange(num_points):
         minor_distance = -1
         for i1 in range(num_centroids):
             dx = arrayP[i0, 0] - arrayC[i1, 0]
             dy = arrayP[i0, 1] - arrayC[i1, 1]
-            my_distance = numpy.sqrt(dx * dx + dy * dy)
+            my_distance = np.sqrt(dx * dx + dy * dy)
             if minor_distance > my_distance or minor_distance == -1:
                 minor_distance = my_distance
                 arrayPcluster[i0] = i1
     return arrayPcluster
 
 
-@nb.jit(nopython=True, parallel=False, fastmath=True)
+@nb.njit(parallel=False, fastmath=True)
 def _calCentroidsSum(
     arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points, num_centroids
 ):
@@ -38,14 +38,14 @@ def _calCentroidsSum(
     return arrayCsum, arrayCnumpoint
 
 
-@nb.jit(nopython=True, parallel=False, fastmath=True)
+@nb.njit(parallel=False, fastmath=True)
 def _updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
     for i in nb.prange(num_centroids):
         arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
         arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@nb.jit(nopython=True, parallel=False, fastmath=True)
+@nb.njit(parallel=False, fastmath=True)
 def _kmeans_impl(
     arrayP,
     arrayPcluster,
@@ -73,7 +73,7 @@ def _kmeans_impl(
     return arrayC, arrayCsum, arrayCnumpoint
 
 
-@nb.jit(nopython=True, parallel=False, fastmath=True)
+@nb.njit(parallel=False, fastmath=True)
 def kmeans(
     arrayP,
     arrayPclusters,

--- a/dpbench/benchmarks/kmeans/kmeans_numba_npr.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_npr.py
@@ -3,24 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numba as nb
-import numpy
+import numpy as np
 
 
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def _groupByCluster(arrayP, arrayPcluster, arrayC, num_points, num_centroids):
     for i0 in nb.prange(num_points):
         minor_distance = -1
         for i1 in range(num_centroids):
             dx = arrayP[i0, 0] - arrayC[i1, 0]
             dy = arrayP[i0, 1] - arrayC[i1, 1]
-            my_distance = numpy.sqrt(dx * dx + dy * dy)
+            my_distance = np.sqrt(dx * dx + dy * dy)
             if minor_distance > my_distance or minor_distance == -1:
                 minor_distance = my_distance
                 arrayPcluster[i0] = i1
     return arrayPcluster
 
 
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def _calCentroidsSum(
     arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points, num_centroids
 ):
@@ -38,14 +38,14 @@ def _calCentroidsSum(
     return arrayCsum, arrayCnumpoint
 
 
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def _updateCentroids(arrayC, arrayCsum, arrayCnumpoint, num_centroids):
     for i in nb.prange(num_centroids):
         arrayC[i, 0] = arrayCsum[i, 0] / arrayCnumpoint[i]
         arrayC[i, 1] = arrayCsum[i, 1] / arrayCnumpoint[i]
 
 
-@nb.jit(nopython=True)
+@nb.njit()
 def _kmeans_impl(
     arrayP,
     arrayPcluster,
@@ -73,7 +73,7 @@ def _kmeans_impl(
     return arrayC, arrayCsum, arrayCnumpoint
 
 
-@nb.jit(nopython=True, parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def kmeans(
     arrayP,
     arrayPclusters,

--- a/dpbench/benchmarks/knn/knn_numba_dpex_k.py
+++ b/dpbench/benchmarks/knn/knn_numba_dpex_k.py
@@ -4,11 +4,11 @@
 
 from math import sqrt
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 import numpy as np
 
 
-@nbdx.kernel
+@dpex.kernel
 def _knn_kernel(
     train,
     train_labels,
@@ -20,9 +20,9 @@ def _knn_kernel(
     votes_to_classes_lst,
     data_dim,
 ):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     # here k has to be 5 in order to match with numpy
-    queue_neighbors = nbdx.private.array(shape=(5, 2), dtype=np.float64)
+    queue_neighbors = dpex.private.array(shape=(5, 2), dtype=np.float64)
 
     for j in range(k):
         x1 = train[j]

--- a/dpbench/benchmarks/knn/knn_numba_dpex_p.py
+++ b/dpbench/benchmarks/knn/knn_numba_dpex_p.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
-import numba
+import numba as nb
 import numpy as np
 
 
-@numba.njit(parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def knn(
     x_train,
     y_train,
@@ -21,7 +19,7 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-    for i in numba.prange(test_size):
+    for i in nb.prange(test_size):
         queue_neighbors = np.empty(shape=(k, 2))
 
         for j in range(k):
@@ -32,7 +30,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             queue_neighbors[j, 0] = dist
             queue_neighbors[j, 1] = y_train[j]
@@ -59,7 +57,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             if dist < queue_neighbors[k - 1][0]:
                 queue_neighbors[k - 1][0] = dist

--- a/dpbench/benchmarks/knn/knn_numba_npr.py
+++ b/dpbench/benchmarks/knn/knn_numba_npr.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
-import numba
+import numba as nb
 import numpy as np
 
 
-@numba.njit(parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def knn(
     x_train,
     y_train,
@@ -21,7 +19,7 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-    for i in numba.prange(test_size):
+    for i in nb.prange(test_size):
         queue_neighbors = np.empty(shape=(k, 2))
 
         for j in range(k):
@@ -32,7 +30,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             queue_neighbors[j, 0] = dist
             queue_neighbors[j, 1] = y_train[j]
@@ -59,7 +57,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = np.sqrt(distance)
 
             if dist < queue_neighbors[k - 1][0]:
                 queue_neighbors[k - 1][0] = dist

--- a/dpbench/benchmarks/knn/knn_python.py
+++ b/dpbench/benchmarks/knn/knn_python.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
+from math import sqrt
 
 import numpy as np
 
@@ -31,7 +31,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = sqrt(distance)
 
             queue_neighbors[j, 0] = dist
             queue_neighbors[j, 1] = y_train[j]
@@ -61,7 +61,7 @@ def knn(
             for jj in range(data_dim):
                 diff = x1[jj] - x2[jj]
                 distance += diff * diff
-            dist = math.sqrt(distance)
+            dist = sqrt(distance)
 
             if dist < queue_neighbors[k - 1][0]:
                 # queue_neighbors[k - 1] = new_neighbor

--- a/dpbench/benchmarks/l2_norm/l2_norm_base.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_base.py
@@ -2,10 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpnp as np
+import numpy as np
 
 
 def l2_norm(a, d):
-    sq = np.square(a)
-    sum = sq.sum(axis=1)
-    d[:] = np.sqrt(sum)
+    d[:] = np.linalg.norm(a, axis=1)

--- a/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 import numpy as np
 
 
-@nbdx.kernel
+@dpex.kernel
 def l2_norm_kernel(a, d):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     O = a.shape[1]
     d[i] = 0.0
     for k in range(O):

--- a/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
@@ -2,18 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
-import numba_dpex
+import numba_dpex as nbdx
 import numpy as np
-from numba_dpex import DEFAULT_LOCAL_SIZE, kernel
-
-atomic_add = numba_dpex.atomic.add
 
 
-@kernel(access_types={"read_only": ["a"], "write_only": ["d"]})
+@nbdx.kernel
 def l2_norm_kernel(a, d):
-    i = numba_dpex.get_global_id(0)
+    i = nbdx.get_global_id(0)
     O = a.shape[1]
     d[i] = 0.0
     for k in range(O):
@@ -22,4 +17,4 @@ def l2_norm_kernel(a, d):
 
 
 def l2_norm(a, d):
-    l2_norm_kernel[a.shape[0], DEFAULT_LOCAL_SIZE](a, d)
+    l2_norm_kernel[a.shape[0],](a, d)

--- a/dpbench/benchmarks/l2_norm/l2_norm_numpy.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_numpy.py
@@ -6,4 +6,6 @@ import numpy as np
 
 
 def l2_norm(a, d):
-    d[:] = np.linalg.norm(a, axis=1)
+    sq = np.square(a)
+    sum = sq.sum(axis=1)
+    d[:] = np.sqrt(sum)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_base.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_base.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+
+def pairwise_distance(X1, X2, D):
+    """Pairwise Numpy implementation using numpy linalg norm"""
+    np.copyto(D, np.linalg.norm(X1[:, None, :] - X2[None, :, :], axis=-1))

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba_dpex
+import numba_dpex as nbdx
 import numpy as np
 
 
-@numba_dpex.kernel
+@nbdx.kernel
 def _pairwise_distance_kernel(X1, X2, D):
-    i = numba_dpex.get_global_id(0)
+    i = nbdx.get_global_id(0)
 
     N = X2.shape[0]
     O = X1.shape[1]
@@ -21,6 +21,4 @@ def _pairwise_distance_kernel(X1, X2, D):
 
 
 def pairwise_distance(X1, X2, D):
-    _pairwise_distance_kernel[X1.shape[0], numba_dpex.DEFAULT_LOCAL_SIZE](
-        X1, X2, D
-    )
+    _pairwise_distance_kernel[X1.shape[0],](X1, X2, D)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 import numpy as np
 
 
-@nbdx.kernel
+@dpex.kernel
 def _pairwise_distance_kernel(X1, X2, D):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
 
     N = X2.shape[0]
     O = X1.shape[1]

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_npr.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_npr.py
@@ -2,16 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numba
+import numba as nb
 import numpy as np
 
 
-@numba.njit(parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def pairwise_distance(X1, X2, D):
     M = X1.shape[0]
     N = X2.shape[0]
     O = X1.shape[1]
-    for i in numba.prange(M):
+    for i in nb.prange(M):
         for j in range(N):
             d = 0.0
             for k in range(O):

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numpy.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numpy.py
@@ -6,5 +6,11 @@ import numpy as np
 
 
 def pairwise_distance(X1, X2, D):
-    """Pairwise Numpy implementation using numpy linalg norm"""
-    np.copyto(D, np.linalg.norm(X1[:, None, :] - X2[None, :, :], axis=-1))
+    x1 = np.sum(np.square(X1), axis=1)
+    x2 = np.sum(np.square(X2), axis=1)
+    np.dot(X1, X2.T, D)
+    D *= -2
+    x3 = x1.reshape(x1.size, 1)
+    np.add(D, x3, D)
+    np.add(D, x2, D)
+    np.sqrt(D, D)

--- a/dpbench/benchmarks/pca/pca_initialize.py
+++ b/dpbench/benchmarks/pca/pca_initialize.py
@@ -6,4 +6,4 @@
 def initialize(npoints, dims):
     from sklearn.datasets import make_regression
 
-    return make_regression(n_samples=npoints, n_features=dims)
+    return make_regression(n_samples=npoints, n_features=dims, random_state=0)

--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_k.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_k.py
@@ -4,12 +4,12 @@
 
 from math import cos, log, pi, sin, sqrt
 
-import numba_dpex as nbdx
+import numba_dpex as dpex
 
 
-@nbdx.kernel
+@dpex.kernel
 def _rambo(C1, F1, Q1, nout, output):
-    i = nbdx.get_global_id(0)
+    i = dpex.get_global_id(0)
     for j in range(nout):
         C = 2.0 * C1[i, j] - 1.0
         S = sqrt(1 - C * C)

--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_k.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_k.py
@@ -2,29 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
+from math import cos, log, pi, sin, sqrt
 
-import numba_dpex
-from numba_dpex import kernel
+import numba_dpex as nbdx
 
 
-@kernel
+@nbdx.kernel
 def _rambo(C1, F1, Q1, nout, output):
-    i = numba_dpex.get_global_id(0)
+    i = nbdx.get_global_id(0)
     for j in range(nout):
         C = 2.0 * C1[i, j] - 1.0
-        S = math.sqrt(1 - C * C)
-        F = 2.0 * math.pi * F1[i, j]
-        Q = -math.log(Q1[i, j])
+        S = sqrt(1 - C * C)
+        F = 2.0 * pi * F1[i, j]
+        Q = -log(Q1[i, j])
 
         output[i, j, 0] = Q
-        output[i, j, 1] = Q * S * math.sin(F)
-        output[i, j, 2] = Q * S * math.cos(F)
+        output[i, j, 1] = Q * S * sin(F)
+        output[i, j, 2] = Q * S * cos(F)
         output[i, j, 3] = Q * C
 
 
 def rambo(nevts, nout, C1, F1, Q1, output):
-    _rambo[nevts, numba_dpex.DEFAULT_LOCAL_SIZE](
+    _rambo[nevts,](
         C1,
         F1,
         Q1,

--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_p.py
@@ -2,21 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import numba as nb
+import numpy as np
 
-import numba
-import numpy
 
-
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@nb.njit(parallel=True, fastmath=True)
 def rambo(nevts, nout, C1, F1, Q1, output):
-    for i in numba.prange(nevts):
+    for i in nb.prange(nevts):
         for j in range(nout):
             C = 2.0 * C1[i, j] - 1.0
-            S = numpy.sqrt(1 - numpy.square(C))
-            F = 2.0 * numpy.pi * F1[i, j]
-            Q = -numpy.log(Q1[i, j])
+            S = np.sqrt(1 - np.square(C))
+            F = 2.0 * np.pi * F1[i, j]
+            Q = -np.log(Q1[i, j])
 
             output[i, j, 0] = Q
-            output[i, j, 1] = Q * S * numpy.sin(F)
-            output[i, j, 2] = Q * S * numpy.cos(F)
+            output[i, j, 1] = Q * S * np.sin(F)
+            output[i, j, 2] = Q * S * np.cos(F)
             output[i, j, 3] = Q * C


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
1) Different workloads were using different styles of import. For eg, some workloads had `import numba_dpex`, some other were using `import numba_dpex as nbd`, etc. Made a sweeping change to have `import numba_dpex as nbdx` in all workloads.
2) Similar to (1), standardizes numba, numpy, dpnp and math import
3) Removes use of default local size from kernel implementations.
4) Ensures implementations across numpy, dpnp, numba_np and numba_dpex_n variants are the same.
5) As a part of this cleanup, removed use of REPEAT in kmeans which was inadvertently carried over from old main. Now repetitions are handled through framwork infrastructure.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
