### PR TITLE
Adding implementations of Rambo using numpy-like vector operations

### DIFF
--- a/dpbench/benchmarks/rambo/rambo_dpnp.py
+++ b/dpbench/benchmarks/rambo/rambo_dpnp.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
+import dpnp as np
 
 
 def rambo(nevts, nout, C1, F1, Q1, output):

--- a/dpbench/benchmarks/rambo/rambo_numba_np.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_np.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import numba as nb
 import numpy as np
 
 
+@nb.njit(parallel=True, fastmath=True)
 def rambo(nevts, nout, C1, F1, Q1, output):
     C = 2.0 * C1 - 1.0
     S = np.sqrt(1 - np.square(C))

--- a/dpbench/benchmarks/rambo/rambo_python.py
+++ b/dpbench/benchmarks/rambo/rambo_python.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+
+def rambo(nevts, nout, C1, F1, Q1, output):
+    for i in range(nevts):
+        for j in range(nout):
+            C = 2.0 * C1[i, j] - 1.0
+            S = np.sqrt(1 - np.square(C))
+            F = 2.0 * np.pi * F1[i, j]
+            Q = -np.log(Q1[i, j])
+
+            output[i, j, 0] = Q
+            output[i, j, 1] = Q * S * np.sin(F)
+            output[i, j, 2] = Q * S * np.cos(F)
+            output[i, j, 3] = Q * C


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Adds dpnp, numba_np, numba_dpex_n implementation of Rambo workload. The numpy implementation was using elementwise operations inside a loop. Moved the elementwise loop based implementation to a python implementation and added a numpy implementation. 

Numba_dpex_n implementation fails validation. Issue has been raised [here](https://github.com/IntelPython/numba-dpex/issues/978)

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
