### PR TITLE
Adjusting timeout

### DIFF
--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -81,7 +81,7 @@ def run_benchmark(
     preset="S",
     repeat=10,
     validate=True,
-    timeout=1000.0,
+    timeout=2000.0,
     conn=None,
     run_datetime=None,
     print_results=True,
@@ -133,7 +133,7 @@ def run_benchmarks(
     preset="S",
     repeat=10,
     validate=True,
-    timeout=1000.0,
+    timeout=2000.0,
     dbfile=None,
     print_results=True,
 ):

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -81,7 +81,7 @@ def run_benchmark(
     preset="S",
     repeat=10,
     validate=True,
-    timeout=200.0,
+    timeout=1000.0,
     conn=None,
     run_datetime=None,
     print_results=True,

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -133,7 +133,7 @@ def run_benchmarks(
     preset="S",
     repeat=10,
     validate=True,
-    timeout=200.0,
+    timeout=1000.0,
     dbfile=None,
     print_results=True,
 ):


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Dpnp implementations of pairwise distance and l2_norm have execution timeouts intermittently. It is likely that these two dpnp implementations are having long execution times. Increasing timeout from 200 seconds to ~~1000~~ 2000 seconds to support longer running times of these workloads.

**Update after 1000 s CI run:** execution timeout in l2_norm dpnp run.
**Update after 2000 s CI run:** execution timeout in l2_norm dpnp run.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
