### PR TITLE
Rambo workload's numba-dpex implementation with dpnp vector operations

### DIFF
--- a/dpbench/benchmarks/rambo/rambo_numba_dpex_n.py
+++ b/dpbench/benchmarks/rambo/rambo_numba_dpex_n.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp as np
+from numba_dpex import dpjit
+
+
+@dpjit
+def rambo(nevts, nout, C1, F1, Q1, output):
+    C = 2.0 * C1 - 1.0
+    S = np.sqrt(1 - np.square(C))
+    F = 2.0 * np.pi * F1
+    Q = -np.log(Q1)
+
+    output[:, :, 0] = Q
+    output[:, :, 1] = Q * S * np.sin(F)
+    output[:, :, 2] = Q * S * np.cos(F)
+    output[:, :, 3] = Q * C


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Adds numba_dpex_n implementation of Rambo workload. ~~It fails validation. Issue has been raised [here](https://github.com/IntelPython/numba-dpex/issues/978)~~ Failed validation fixed in [numba-dpex](https://github.com/IntelPython/numba-dpex/pull/1023).

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
