### PR TITLE
Some code cleanups

### DIFF
--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <CL/sycl.hpp>
-#include <mathimf.h>
 
 using namespace sycl;
 

--- a/dpbench/benchmarks/rambo/rambo_sycl_native_ext/rambo_sycl/_rambo_kernel.hpp
+++ b/dpbench/benchmarks/rambo/rambo_sycl_native_ext/rambo_sycl/_rambo_kernel.hpp
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// For M_PI
+#define _USE_MATH_DEFINES
+
 #include <CL/sycl.hpp>
+#include <math.h>
 #include <stdlib.h>
 #include <type_traits>
 

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -588,11 +588,11 @@ class BenchmarkRunner:
 
                         output_npz = results_dict["outputs"]
                         if output_npz:
-                            npzfile = np.load(output_npz)
-                            for outarr in npzfile.files:
-                                self.results.results.update(
-                                    {outarr: npzfile[outarr]}
-                                )
+                            with np.load(output_npz) as npzfile:
+                                for outarr in npzfile.files:
+                                    self.results.results.update(
+                                        {outarr: npzfile[outarr]}
+                                    )
                             os.remove(output_npz)
                         if results_dict["return-value"]:
                             self.results.results.update(

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -71,7 +71,6 @@ def _exec(
     fmwrk,
     impl_postfix,
     preset,
-    timeout,
     repeat,
     get_args,
     results_dict,
@@ -542,13 +541,12 @@ class BenchmarkRunner:
             with Manager() as manager:
                 results_dict = manager.dict()
                 p = Process(
-                    target=tout.exit_after(timeout)(_exec),
+                    target=_exec,
                     args=(
                         self.bench,
                         self.fmwrk,
                         impl_postfix,
                         preset,
-                        timeout,
                         repeat,
                         partial(
                             _setup_func,
@@ -560,7 +558,7 @@ class BenchmarkRunner:
                     ),
                 )
                 p.start()
-                res = p.join(timeout * 1.2)
+                res = p.join(timeout)
                 if res is None and p.exitcode is None:
                     logging.error(
                         "Terminating process due to timeout in the execution "


### PR DESCRIPTION
* Remove unused `#include <mathimf.h>` (also, compiler cannot find this file on Windows)
* Add `_USE_MATH_DEFINES` needed for M_PI on windows
* Remove `tout.exit_after` as we now have timeout in join and it causes issues with pickle on some configurations
* Close npz file before deleting