### PR TITLE
Add performance report

### DIFF
--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -21,7 +21,7 @@ from .dpnp_framework import DpnpFramework
 from .framework import Framework
 from .numba_dpex_framework import NumbaDpexFramework
 from .numba_framework import NumbaFramework
-from .reporter import generate_impl_summary_report
+from .reporter import generate_impl_summary_report, generate_performance_report
 from .utilities import validate
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "create_run",
     "store_results",
     "generate_impl_summary_report",
+    "generate_performance_report",
     "validate",
     "get_supported_implementation_postfixes",
 ]

--- a/dpbench/infrastructure/reporter.py
+++ b/dpbench/infrastructure/reporter.py
@@ -9,7 +9,7 @@ from a specific benchmark run.
 """
 
 import pathlib
-from typing import Union
+from typing import Final, Union
 
 import pandas as pd
 import sqlalchemy
@@ -20,22 +20,96 @@ from . import datamodel as dm
 
 __all__ = [
     "generate_impl_summary_report",
+    "generate_performance_report",
 ]
+
+
+def update_run_id(conn: sqlalchemy.Engine, run_id: Union[int, None]) -> int:
+    """checks if run_id was provided. Otherwise returns the latest available one"""
+    if run_id is not None:
+        return run_id
+
+    with Session(conn) as session:
+        run_id = (
+            session.query(
+                dm.Run.id,
+            )
+            .order_by(dm.Run.created_at.desc())
+            .limit(1)
+            .scalar()
+        )
+
+        print(
+            f"WARNING: run_id was not provided, using the latest one {run_id}"
+        )
+
+
+def update_connection(
+    results_db: Union[str, sqlalchemy.Engine] = "results.db",
+) -> sqlalchemy.Engine:
+    """checks if database provided as a path and returns sqlalchemy.Engine"""
+    if not isinstance(results_db, sqlalchemy.Engine):
+        return dm.create_connection(db_file=results_db)
+
+    return results_db
+
+
+def read_legends() -> pd.DataFrame:
+    """reads implementation postfixes"""
+    parent_folder = pathlib.Path(__file__).parent.absolute()
+    impl_postfix_path = parent_folder.joinpath(
+        "..", "configs", "impl_postfix.json"
+    )
+    return pd.read_json(impl_postfix_path)
+
+
+def generate_header(conn: sqlalchemy.Engine, run_id: int):
+    """prints header section"""
+    with Session(conn) as session:
+        created_at = (
+            session.query(
+                func.datetime(dm.Run.created_at, "unixepoch", "localtime"),
+            )
+            .where(dm.Run.id == run_id)
+            .limit(1)
+            .scalar()
+        )
+
+        print(f"Report for {created_at} run")
+        print("==================================")
+
+
+def generate_legend(legends: pd.DataFrame):
+    """prints legend section"""
+    formatters = {}
+    for col in legends.select_dtypes("object"):
+        len_max = legends[col].str.len().max()
+        formatters[col] = lambda _, len_max=len_max: f"{_:<{len_max}s}"
+
+    print("Legend")
+    print("======")
+    print(legends.to_string(formatters=formatters))
+    print("")
+
+
+def generate_summary(data: pd.DataFrame):
+    """prints summary section"""
+    print("Summary of current implementation")
+    print("=================================")
+    print(data.to_string())
 
 
 def generate_impl_summary_report(
     results_db: Union[str, sqlalchemy.Engine] = "results.db",
     run_id: int = None,
 ):
-    conn = results_db
-    if not isinstance(conn, sqlalchemy.Engine):
-        conn = dm.create_connection(db_file=results_db)
+    """generate implementation summary report with status of each benchmark"""
+    conn = update_connection(results_db=results_db)
+    run_id = update_run_id(conn, run_id)
+    legends = read_legends()
 
-    parent_folder = pathlib.Path(__file__).parent.absolute()
-    impl_postfix_path = parent_folder.joinpath(
-        "..", "configs", "impl_postfix.json"
-    )
-    legends = pd.read_json(impl_postfix_path)
+    generate_header(conn, run_id)
+    generate_legend(legends)
 
     columns = [
         dm.Result.input_size_human.label("input_size"),
@@ -59,49 +133,86 @@ def generate_impl_summary_report(
             ).label(impl),
         )
 
-    sql = sqlalchemy.select(*columns).group_by(
-        dm.Result.benchmark,
-        dm.Result.problem_preset,
-    )
-    if not run_id:
-        with Session(conn) as session:
-            run_id = (
-                session.query(
-                    dm.Run.id,
-                )
-                .order_by(dm.Run.created_at.desc())
-                .limit(1)
-                .scalar()
-            )
-
-            print(
-                f"WARNING: run_id was not provided, using the latest one {run_id}"
-            )
-
-    with Session(conn) as session:
-        created_at = (
-            session.query(
-                func.datetime(dm.Run.created_at, "unixepoch", "localtime"),
-            )
-            .where(dm.Run.id == run_id)
-            .limit(1)
-            .scalar()
+    sql = (
+        sqlalchemy.select(*columns)
+        .group_by(
+            dm.Result.benchmark,
+            dm.Result.problem_preset,
         )
-
-        print(f"Report for {created_at} run")
-        print("==================================")
-
-    sql = sql.where(dm.Result.run_id == run_id)
+        .where(
+            dm.Result.run_id == run_id,
+        )
+    )
 
     df = pd.read_sql_query(
         sql=sql,
         con=conn.connect(),
     )
 
-    print("Legend")
-    print("======")
-    print(legends)
-    print("")
-    print("Summary of current implementation")
-    print("=================================")
-    print(df.to_string())
+    generate_summary(df)
+
+
+def generate_performance_report(
+    results_db: Union[str, sqlalchemy.Engine] = "results.db",
+    run_id: int = None,
+):
+    """generate performance report with median times for each benchmark"""
+    conn = update_connection(results_db=results_db)
+    run_id = update_run_id(conn, run_id)
+    legends = read_legends()
+
+    generate_header(conn, run_id)
+    generate_legend(legends)
+
+    columns = [
+        dm.Result.input_size_human.label("input_size"),
+        dm.Result.benchmark,
+        dm.Result.problem_preset,
+    ]
+
+    for _, row in legends.iterrows():
+        impl = row["impl_postfix"]
+        columns.append(
+            func.ifnull(
+                func.max(
+                    case(
+                        (
+                            dm.Result.implementation == impl,
+                            dm.Result.median_exec_time,
+                        ),
+                    )
+                ),
+                None,
+            ).label(impl),
+        )
+
+    sql = (
+        sqlalchemy.select(*columns)
+        .group_by(
+            dm.Result.benchmark,
+            dm.Result.problem_preset,
+        )
+        .where(dm.Result.run_id == run_id)
+    )
+
+    df = pd.read_sql_query(
+        sql=sql,
+        con=conn.connect(),
+    )
+
+    for index, row in df.iterrows():
+        for _, legend_row in legends.iterrows():
+            impl = legend_row["impl_postfix"]
+
+            time = row[impl]
+            if time:
+                NANOSECONDS_IN_MILISECONDS: Final[float] = 1000 * 1000.0
+                time /= NANOSECONDS_IN_MILISECONDS
+
+                time = str(round(time, 2)) + "ms"
+            else:
+                time = "n/a"
+
+            df.at[index, impl] = time
+
+    generate_summary(df)


### PR DESCRIPTION
Example:
```
Report for 2023-04-07 18:18:14 run
==================================
Legend
======
   impl_postfix                                    description
0  numba_dpex_k                         Numba-dpex with kernel
1  numba_dpex_p                         Numba-dpex with prange
2  numba_dpex_n         Numba-dpex with NumPy array expression
3          dpnp                   Data-parallel Numeric Python
4         numpy                                          Numpy
5        python                                         Python
6       numba_n                            Numba with nopython
7      numba_np             Numba with nopython, Parallel=True
8     numba_npr  Numba with nopython, Parallel=True and prange
9          sycl                      DPC++ with dpctl bindings

Summary of current performance
=================================
  input_size          benchmark problem_preset     numba_dpex_k     numba_dpex_p   numba_dpex_n                dpnp       numpy           python         numba_n        numba_np      numba_npr            sycl
0       15MB      black_scholes              S    0.03s, 14.98%    0.01s, -33.8%  0.04s, 94.62%      0.11s, 393.08%  0.02s, ref  0.36s, 1549.92%  0.02s, -29.47%   0.0s, -94.47%  0.0s, -94.57%   0.0s, -95.72%
1       80KB             dbscan              S   0.08s, 972.35%    0.02s, 134.5%            n/a                 n/a         n/a       0.01s, ref   0.01s, 61.86%             n/a  0.0s, -60.48%   0.0s, -63.67%
2        4KB             gpairs              S  0.05s, 7767.25%  0.03s, 5088.03%            n/a    0.09s, 13422.42%   0.0s, ref              n/a   0.0s, -52.48%             n/a  0.0s, -74.58%    0.0s, -56.0%
3       94KB             kmeans              S   0.73s, 275.32%   0.59s, 202.94%            n/a                 n/a         n/a       0.19s, ref   0.0s, -99.27%             n/a  0.0s, -99.32%  0.01s, -97.35%
4      296KB                knn              S    0.03s, -99.0%              n/a            n/a                 n/a         n/a       3.06s, ref             n/a             n/a  0.0s, -99.92%   0.0s, -99.93%
5        1MB            l2_norm              S  0.01s, 3410.52%  0.01s, 2922.57%            n/a  8.66s, 2780288.33%   0.0s, ref              n/a   0.0s, -23.67%   0.0s, -36.36%  0.0s, -80.97%   0.0s, -26.95%
6        8MB  pairwise_distance              S    0.02s, 62.59%     0.01s, 3.76%            n/a                 n/a  0.01s, ref              n/a             n/a    0.02s, 82.4%  0.0s, -91.18%   0.0s, -92.13%
7         0B                pca              S              n/a              n/a            n/a                 n/a  0.03s, ref              n/a  0.07s, 111.03%  0.02s, -22.24%            n/a             n/a
8        7MB              rambo              S   0.03s, 443.15%   0.01s, 159.89%            n/a      0.04s, 641.58%  0.01s, ref   0.4s, 7603.52%   0.0s, -34.08%   0.0s, -80.92%  0.0s, -82.23%   0.0s, -88.21%
```

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
