### PR TITLE
Ignore modules which failed to load

### DIFF
--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -647,7 +647,14 @@ class Benchmark(object):
             bmod, allowed_implementation_postfixes
         ).items():
             module_name = f"dpbench.benchmarks.{self.bname}.{module_name}"
-            mod = importlib.import_module(module_name)
+            try:
+                mod = importlib.import_module(module_name)
+            except Exception:
+                logging.exception(
+                    f"Failed to import benchmark module: {module_name}"
+                )
+                continue
+
             canonical_name = f"{self.bname}_{postfix}"
 
             func_name: str = None


### PR DESCRIPTION
Ignore benchmark impl module load failure instead of hard-failing.
This was the original intent behind explicit module import removal. This change will allow to run benchmarks even if some of them failed to load (e.g. when numba-mlir and numba-dpex cannot live together in same environment).

