### PR TITLE
Use _like in benchmark allocations

### DIFF
--- a/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_dpex_k.py
@@ -123,8 +123,10 @@ def compute_clusters(n, min_pts, assignments, sizes, indices_list):
 
 
 def dbscan(n_samples, n_features, data, eps, min_pts):
-    indices_list = np.empty(n_samples * n_samples, dtype=np.int64)
-    sizes = np.zeros(n_samples, dtype=np.int64)
+    indices_list = np.empty_like(
+        data, shape=n_samples * n_samples, dtype=np.int64
+    )
+    sizes = np.zeros_like(data, shape=n_samples, dtype=np.int64)
 
     get_neighborhood[n_samples,](
         n_samples,

--- a/dpbench/benchmarks/dbscan/dbscan_numba_dpex_p.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_dpex_p.py
@@ -124,8 +124,10 @@ def compute_clusters(n, min_pts, assignments, sizes, indices_list):
 
 
 def dbscan(n_samples, n_features, data, eps, min_pts):
-    indices_list = np.empty(n_samples * n_samples, dtype=np.int64)
-    sizes = np.zeros(n_samples, dtype=np.int64)
+    indices_list = np.empty_like(
+        data, shape=n_samples * n_samples, dtype=np.int64
+    )
+    sizes = np.zeros_like(data, shape=n_samples, dtype=np.int64)
 
     get_neighborhood(n_samples, n_features, data, eps, indices_list, sizes)
 

--- a/dpbench/benchmarks/dbscan/dbscan_numba_n.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_n.py
@@ -122,8 +122,10 @@ def compute_clusters(n, min_pts, assignments, sizes, indices_list):
 
 
 def dbscan(n_samples, n_features, data, eps, min_pts):
-    indices_list = np.empty(n_samples * n_samples, dtype=np.int64)
-    sizes = np.zeros(n_samples, dtype=np.int64)
+    indices_list = np.empty_like(
+        data, shape=n_samples * n_samples, dtype=np.int64
+    )
+    sizes = np.zeros_like(data, shape=n_samples, dtype=np.int64)
 
     get_neighborhood(n_samples, n_features, data, eps, indices_list, sizes)
 

--- a/dpbench/benchmarks/dbscan/dbscan_numba_npr.py
+++ b/dpbench/benchmarks/dbscan/dbscan_numba_npr.py
@@ -122,8 +122,10 @@ def compute_clusters(n, min_pts, assignments, sizes, indices_list):
 
 
 def dbscan(n_samples, n_features, data, eps, min_pts):
-    indices_list = np.empty(n_samples * n_samples, dtype=np.int64)
-    sizes = np.zeros(n_samples, dtype=np.int64)
+    indices_list = np.empty_like(
+        data, shape=n_samples * n_samples, dtype=np.int64
+    )
+    sizes = np.zeros_like(data, shape=n_samples, dtype=np.int64)
 
     get_neighborhood(n_samples, n_features, data, eps, indices_list, sizes)
 

--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_p.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_p.py
@@ -52,7 +52,7 @@ def count_weighted_pairs_3d_diff_agg_ker(nbins, result, n):
 
 def gpairs(nopt, nbins, x1, y1, z1, w1, x2, y2, z2, w2, rbins, results):
     # allocate per-work item private result vector in device global memory
-    results_disjoint = np.zeros((nopt, rbins.shape[0]), dtype=np.float32)
+    results_disjoint = np.zeros_like(results, shape=(nopt, rbins.shape[0]))
 
     # call gpairs compute kernel
     count_weighted_pairs_3d_diff_ker(

--- a/dpbench/benchmarks/gpairs/gpairs_numba_npr.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_npr.py
@@ -51,7 +51,7 @@ def count_weighted_pairs_3d_diff_agg_ker(nbins, result, n):
 
 def gpairs(nopt, nbins, x1, y1, z1, w1, x2, y2, z2, w2, rbins, results):
     # allocate per-work item private result vector in device global memory
-    results_disjoint = np.zeros((nopt, rbins.shape[0]), dtype=np.float32)
+    results_disjoint = np.zeros_like(results, shape=(nopt, rbins.shape[0]))
 
     # call gpairs compute kernel
     count_weighted_pairs_3d_diff_ker(


### PR DESCRIPTION
Some benchmarks where failing, because allocation device was not set.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
