### PR TITLE
Add comparison report

### DIFF
--- a/dpbench/console/_namespace.py
+++ b/dpbench/console/_namespace.py
@@ -28,3 +28,26 @@ class Namespace(argparse.Namespace):
     timeout: float
     precision: Union[str, None]
     program: str
+    comparisons: list[str]
+
+
+class CommaSeparateStringAction(argparse.Action):
+    """Action that reads comma separated string into set of strings.
+
+    This action supposed to be used in argparse argument.
+    """
+
+    def __call__(self, _, namespace, values, __):
+        """Split values into set of strings."""
+        setattr(namespace, self.dest, set(values.split(",")))
+
+
+class CommaSeparateStringListAction(argparse.Action):
+    """Action that reads comma separated string into set of strings.
+
+    This action supposed to be used in argparse argument.
+    """
+
+    def __call__(self, _, namespace, values, __):
+        """Split values into list of strings."""
+        setattr(namespace, self.dest, values.split(","))

--- a/dpbench/console/entry.py
+++ b/dpbench/console/entry.py
@@ -7,20 +7,9 @@
 import argparse
 from importlib.metadata import version
 
-from ._namespace import Namespace
+from ._namespace import CommaSeparateStringAction, Namespace
 from .report import add_report_arguments, execute_report
 from .run import add_run_arguments, execute_run
-
-
-class CommaSeparateStringAction(argparse.Action):
-    """Action that reads comma separated string into set of strings.
-
-    This action supposed to be used in argparse argument.
-    """
-
-    def __call__(self, _, namespace, values, __):
-        """Split values into set of strings."""
-        setattr(namespace, self.dest, set(values.split(",")))
 
 
 def parse_args() -> Namespace:

--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -21,6 +21,7 @@ from .frameworks import (
     NumbaMlirFramework,
 )
 from .reporter import (
+    generate_comparison_report,
     generate_impl_summary_report,
     generate_performance_report,
     get_unexpected_failures,
@@ -45,6 +46,7 @@ __all__ = [
     "store_results",
     "generate_impl_summary_report",
     "generate_performance_report",
+    "generate_comparison_report",
     "get_unexpected_failures",
     "validate",
 ]

--- a/dpbench/infrastructure/runner.py
+++ b/dpbench/infrastructure/runner.py
@@ -213,6 +213,7 @@ def print_report(
     conn: sqlalchemy.Engine,
     run_id: int,
     implementations: set[str],
+    comparison_pairs: list[tuple[str, str]] = [],
 ):
     if not implementations:
         implementations = {impl.postfix for impl in cfg.GLOBAL.implementations}
@@ -228,6 +229,14 @@ def print_report(
         conn,
         run_id=run_id,
         implementations=implementations,
+        headless=True,
+    )
+
+    dpbi.generate_comparison_report(
+        conn,
+        run_id=run_id,
+        implementations=implementations,
+        comparison_pairs=comparison_pairs,
         headless=True,
     )
 


### PR DESCRIPTION
Add `--comparisons` option to `report` command:

```
$ pbench report --help
usage: dpbench report [-h] [-c [COMPARISONS]]

Subcommand to generate report for the existing run.

options:
  -h, --help            show this help message and exit
  -c [COMPARISONS], --comparisons [COMPARISONS]
                        Comma separated list of implementation pairs that need to be compared.
```


```bash
dpbench -r1 report --comparisons=python,numpy,numpy,python
```

```
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Report for 2023-04-07 18:18:14 run
==================================
Legend
======
  postfix description
0  python      Python
1  numpy       NumPy

Summary of current implementation
=================================
  input_size          benchmark problem_preset          numpy         python
0       15MB      black_scholes              S        Success        Success
1       80KB             dbscan              S  Unimplemented        Success
2         0B             gpairs              S        Success  Unimplemented
3       94KB             kmeans              S  Unimplemented        Success
4      296KB                knn              S  Unimplemented        Success
5         0B            l2_norm              S        Success  Unimplemented
6         0B  pairwise_distance              S        Success  Unimplemented
7         0B                pca              S        Success  Unimplemented
8        7MB              rambo              S        Success        Success
Summary of current implementation
=================================
  input_size          benchmark problem_preset    numpy    python
0       15MB      black_scholes              S  22.11ms  364.79ms
1       80KB             dbscan              S      n/a    7.01ms
2         0B             gpairs              S   0.64ms       n/a
3       94KB             kmeans              S      n/a  193.72ms
4      296KB                knn              S      n/a  3061.2ms
5         0B            l2_norm              S   0.31ms       n/a
6         0B  pairwise_distance              S  11.26ms       n/a
7         0B                pca              S  31.44ms       n/a
8        7MB              rambo              S   5.23ms  403.13ms
Summary of current implementation
=================================
  input_size          benchmark problem_preset python_to_numpy numpy_to_python
0       15MB      black_scholes              S        1649.92%           6.06%
1       80KB             dbscan              S             n/a             n/a
2         0B             gpairs              S             n/a             n/a
3       94KB             kmeans              S             n/a             n/a
4      296KB                knn              S             n/a             n/a
5         0B            l2_norm              S             n/a             n/a
6         0B  pairwise_distance              S             n/a             n/a
7         0B                pca              S             n/a             n/a
8        7MB              rambo              S        7703.52%            1.3%
```


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
