### PR TITLE
Add config dataclasses and reader

### DIFF
--- a/dpbench/config/__init__.py
+++ b/dpbench/config/__init__.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Config sub-package with benchmark, frameworks settings, etc.
+
+The config sub-package is a module that contains a set of data classes that
+define a benchmarking framework's configuration. The data classes are designed
+to provide a structured way to define and store benchmark data.
+"""
+
+import json
+import os
+
+from .benchmark import Benchmark
+from .config import Config
+from .framework import Framework
+from .implementaion_postfix import Implementation
+
+
+def read_configs(dirname: str = os.path.dirname(__file__)) -> Config:
+    """Read all configuration files and populates those settings into Config."""
+    C: Config = Config([], [], [])
+
+    impl_postfix_file = os.path.join(dirname, "../configs/impl_postfix.json")
+    bench_info_dir = os.path.join(dirname, "../configs/bench_info")
+    framework_info_dir = os.path.join(dirname, "../configs/framework_info")
+
+    for bench_info_file in os.listdir(bench_info_dir):
+        if not bench_info_file.endswith(".json"):
+            continue
+
+        bench_info_file = os.path.join(bench_info_dir, bench_info_file)
+
+        with open(bench_info_file) as file:
+            file_contents = file.read()
+
+        bench_info = json.loads(file_contents)
+        benchmark = Benchmark.from_dict(bench_info.get("benchmark"))
+        C.benchmarks.append(benchmark)
+
+    for framework_info_file in os.listdir(framework_info_dir):
+        if not framework_info_file.endswith(".json"):
+            continue
+
+        framework_info_file = os.path.join(
+            framework_info_dir, framework_info_file
+        )
+
+        with open(framework_info_file) as file:
+            file_contents = file.read()
+
+        framework_info = json.loads(file_contents)
+        framework_dict = framework_info.get("framework")
+        if framework_dict:
+            framework = Framework.from_dict(framework_dict)
+            C.frameworks.append(framework)
+
+    with open(impl_postfix_file) as file:
+        file_contents = file.read()
+
+    implementaion_postfixes = json.loads(file_contents)
+    for impl in implementaion_postfixes:
+        implementation = Implementation.from_dict(impl)
+        C.implementations.append(implementation)
+
+    return C
+
+
+"""Use this variable for reading configurations"""
+C: Config = read_configs()

--- a/dpbench/config/benchmark.py
+++ b/dpbench/config/benchmark.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark related configuration classes."""
+
+from dataclasses import dataclass
+from typing import Any, List
+
+Parameters = dict[str, Any]
+
+Presets = dict[str, Parameters]
+
+
+@dataclass
+class Init:
+    """Configuration for benchmark initialization."""
+
+    func_name: str
+    input_args: List[str]
+    output_args: List[str]
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Init":
+        """Convert object into Init dataclass."""
+        _func_name = str(obj.get("func_name"))
+        _input_args = obj.get("input_args")
+        _output_args = obj.get("output_args")
+        return Init(_func_name, _input_args, _output_args)
+
+
+@dataclass
+class Benchmark:
+    """Configuration with benchmark information."""
+
+    name: str
+    short_name: str
+    relative_path: str
+    module_name: str
+    func_name: str
+    kind: str
+    domain: str
+    parameters: Presets
+    init: Init
+    input_args: List[str]
+    array_args: List[str]
+    output_args: List[str]
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Benchmark":
+        """Convert object into Benchamrk dataclass."""
+        _name = str(obj.get("name"))
+        _short_name = str(obj.get("short_name"))
+        _relative_path = str(obj.get("relative_path"))
+        _module_name = str(obj.get("module_name"))
+        _func_name = str(obj.get("func_name"))
+        _kind = str(obj.get("kind"))
+        _domain = str(obj.get("domain"))
+        _parameters = Presets(obj.get("parameters"))
+        _init = Init.from_dict(obj.get("init"))
+        _input_args = obj.get("input_args")
+        _array_args = obj.get("input_args")
+        _output_args = obj.get("input_args")
+        return Benchmark(
+            _name,
+            _short_name,
+            _relative_path,
+            _module_name,
+            _func_name,
+            _kind,
+            _domain,
+            _parameters,
+            _init,
+            _input_args,
+            _array_args,
+            _output_args,
+        )

--- a/dpbench/config/config.py
+++ b/dpbench/config/config.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration root related configuration classes."""
+
+from dataclasses import dataclass
+
+from .benchmark import Benchmark
+from .framework import Framework
+from .implementaion_postfix import Implementation
+
+
+@dataclass
+class Config:
+    """Root of the configuration."""
+
+    frameworks: list[Framework]
+    benchmarks: list[Benchmark]
+    implementations: list[Implementation]

--- a/dpbench/config/framework.py
+++ b/dpbench/config/framework.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework related configuration classes."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Framework:
+    """Configuration with framework information."""
+
+    simple_name: str
+    full_name: str
+    prefix: str
+    class_: str
+    arch: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Framework":
+        """Convert object into Framework dataclass."""
+        _simple_name = str(obj.get("simple_name"))
+        _full_name = str(obj.get("full_name"))
+        _prefix = str(obj.get("prefix"))
+        _class = str(obj.get("class"))
+        _arch = str(obj.get("arch"))
+        return Framework(_simple_name, _full_name, _prefix, _class, _arch)

--- a/dpbench/config/implementaion_postfix.py
+++ b/dpbench/config/implementaion_postfix.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation related configuration classes."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Implementation:
+    """Configuration with implementation information."""
+
+    impl_postfix: str
+    description: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Implementation":
+        """Convert object into Implementation dataclass."""
+        _impl_postfix = str(obj.get("impl_postfix"))
+        _description = str(obj.get("description"))
+        return Implementation(_impl_postfix, _description)

--- a/dpbench/config/runner.py
+++ b/dpbench/config/runner.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
-#
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Creates new dataclasses to store configs. It is just an init PR. Feature PRs will target migrating usage of the existing config files into using `dpbench.config.C`. 

To test changes simply run `python -c "import dpbench.config as cfg; print(cfg.C)"`:

```
Config(frameworks=[Framework(simple_name='numpy', full_name='NumPy', prefix='np', class_='Framework', arch='cpu'), Framework(simple_name='numba_dpex', full_name='numba_dpex', prefix='dpex', class_='NumbaDpexFramework', arch='cpu'), Framework(simple_name='python', full_name='Python', prefix='python', class_='Framework', arch='cpu'), Framework(simple_name='numba', full_name='Numba', prefix='nb', class_='NumbaFramework', arch='cpu'), Framework(simple_name='dpnp', full_name='dpnp', prefix='dp', class_='Framework', arch='cpu'), Framework(simple_name='dpcpp', full_name='dpcpp', prefix='dp', class_='DpcppFramework', arch='cpu')], benchmarks=[Benchmark(name='k-Nearest Neighbors', short_name='knn', relative_path='knn', module_name='knn', func_name='knn', kind='microbenchmark', domain='Supervised Learning', parameters=Parameters(S={'test_size': 1024, 'train_size': 1024, 'data_dim': 16, 'classes_num': 3, 'seed_test': 777777, 'seed_train': 0, 'k': 5}, M={'test_size': 8388608, 'train_size': 1024, 'data_dim': 16, 'classes_num': 3, 'seed_test': 777777, 'seed_train': 0, 'k': 5}, L={'test_size': 16777216, 'train_size': 1024, 'data_dim': 16, 'classes_num': 3, 'seed_test': 777777, 'seed_train': 0, 'k': 5}), init=Init(func_name='initialize', input_args=['test_size', 'train_size', 'data_dim', 'classes_num', 'seed_test', 'seed_train'], output_args=['x_train', 'y_train', 'x_test', 'predictions', 'votes_to_classes']), input_args=['x_train', 'y_train', 'x_test', 'k', 'classes_num', 'train_size', 'test_size', 'predictions', 'votes_to_classes', 'data_dim'], array_args=['x_train', 'y_train', 'x_test', 'k', 'classes_num', 'train_size', 'test_size', 'predictions', 'votes_to_classes', 'data_dim'], output_args=['x_train', 'y_train', 'x_test', 'k', 'classes_num', 'train_size', 'test_size', 'predictions', 'votes_to_classes', 'data_dim']), Benchmark(name='Pairwise Distance Computation', short_name='pairwise-distance', relative_path='pairwise_distance', module_name='pairwise_distance', func_name='pairwise_distance', kind='microbenchmark', domain='Distance Compute', parameters=Parameters(S={'npoints': 1024, 'dims': 3, 'seed': 7777777}, M={'npoints': 32768, 'dims': 3, 'seed': 7777777}, L={'npoints': 65536, 'dims': 3, 'seed': 7777777}), init=Init(func_name='initialize', input_args=['npoints', 'dims', 'seed'], output_args=['X1', 'X2', 'D']), input_args=['X1', 'X2', 'D'], array_args=['X1', 'X2', 'D'], output_args=['X1', 'X2', 'D']), Benchmark(name='KMeans', short_name='kmeans', relative_path='kmeans', module_name='kmeans', func_name='kmeans', kind='microbenchmark', domain='Machine Learning', parameters=Parameters(S={'npoints': 4096, 'niters': 10, 'seed': 7777777, 'ndims': 2, 'ncentroids': 10}, M={'npoints': 1048576, 'niters': 30, 'seed': 7777777, 'ndims': 2, 'ncentroids': 10}, L={'npoints': 2097152, 'niters': 30, 'seed': 7777777, 'ndims': 2, 'ncentroids': 10}), init=Init(func_name='initialize', input_args=['npoints', 'niters', 'seed', 'ndims', 'ncentroids'], output_args=['arrayP', 'arrayPclusters', 'arrayC', 'arrayCsum', 'arrayCnumpoint']), input_args=['arrayP', 'arrayPclusters', 'arrayC', 'arrayCsum', 'arrayCnumpoint', 'niters', 'npoints', 'ndims', 'ncentroids'], array_args=['arrayP', 'arrayPclusters', 'arrayC', 'arrayCsum', 'arrayCnumpoint', 'niters', 'npoints', 'ndims', 'ncentroids'], output_args=['arrayP', 'arrayPclusters', 'arrayC', 'arrayCsum', 'arrayCnumpoint', 'niters', 'npoints', 'ndims', 'ncentroids']), Benchmark(name='Black-Scholes Formula', short_name='black-scholes', relative_path='black_scholes', module_name='black_scholes', func_name='black_scholes', kind='microbenchmark', domain='Finance', parameters=Parameters(S={'nopt': 524288, 'seed': 777777}, M={'nopt': 134217728, 'seed': 777777}, L={'nopt': 268435456, 'seed': 777777}), init=Init(func_name='initialize', input_args=['nopt', 'seed'], output_args=['nopt', 'price', 'strike', 't', 'rate', 'volatility', 'call', 'put']), input_args=['nopt', 'price', 'strike', 't', 'rate', 'volatility', 'call', 'put'], array_args=['nopt', 'price', 'strike', 't', 'rate', 'volatility', 'call', 'put'], output_args=['nopt', 'price', 'strike', 't', 'rate', 'volatility', 'call', 'put']), Benchmark(name='Density-based spatial clustering of applications with noise', short_name='DBSCAN', relative_path='dbscan', module_name='dbscan', func_name='dbscan', kind='microbenchmark', domain='Machine Learning', parameters=Parameters(S={'n_samples': 1024, 'n_features': 10, 'centers': 10, 'seed': 777777}, M={'n_samples': 8192, 'n_features': 10, 'centers': 10, 'seed': 777777}, L={'n_samples': 16384, 'n_features': 10, 'centers': 10, 'seed': 777777}), init=Init(func_name='initialize', input_args=['n_samples', 'n_features', 'centers', 'seed'], output_args=['data', 'eps', 'min_pts']), input_args=['n_samples', 'n_features', 'data', 'eps', 'min_pts'], array_args=['n_samples', 'n_features', 'data', 'eps', 'min_pts'], output_args=['n_samples', 'n_features', 'data', 'eps', 'min_pts']), Benchmark(name='L2 Computation', short_name='l2-norm', relative_path='l2_norm', module_name='l2_norm', func_name='l2_norm', kind='microbenchmark', domain='Distance Compute', parameters=Parameters(S={'npoints': 32768, 'dims': 3, 'seed': 777777}, M={'npoints': 268435456, 'dims': 3, 'seed': 777777}, L={'npoints': 536870912, 'dims': 3, 'seed': 777777}), init=Init(func_name='initialize', input_args=['npoints', 'dims', 'seed'], output_args=['a', 'd']), input_args=['a', 'd'], array_args=['a', 'd'], output_args=['a', 'd']), Benchmark(name='Principle Component Analysis', short_name='PCA', relative_path='pca', module_name='pca', func_name='pca', kind='benchmark', domain='data analysis', parameters=Parameters(S={'npoints': 1024, 'dims': 128}, M={'npoints': 16384, 'dims': 128}, L={'npoints': 524288, 'dims': 128}), init=Init(func_name='initialize', input_args=['npoints', 'dims'], output_args=['data']), input_args=['data'], array_args=['data'], output_args=['data']), Benchmark(name='GPairs', short_name='gpairs', relative_path='gpairs', module_name='gpairs', func_name='gpairs', kind='microbenchmark', domain='Astrophysics', parameters=Parameters(S={'nopt': 128, 'seed': 1234, 'nbins': 20, 'rmax': 50, 'rmin': 0.1}, M={'nopt': 65536, 'seed': 1234, 'nbins': 20, 'rmax': 50, 'rmin': 0.1}, L={'nopt': 524288, 'seed': 1234, 'nbins': 20, 'rmax': 50, 'rmin': 0.1}), init=Init(func_name='initialize', input_args=['nopt', 'seed', 'nbins', 'rmax', 'rmin'], output_args=['x1', 'y1', 'z1', 'w1', 'x2', 'y2', 'z2', 'w2', 'rbins', 'results']), input_args=['nopt', 'nbins', 'x1', 'y1', 'z1', 'w1', 'x2', 'y2', 'z2', 'w2', 'rbins', 'results'], array_args=['nopt', 'nbins', 'x1', 'y1', 'z1', 'w1', 'x2', 'y2', 'z2', 'w2', 'rbins', 'results'], output_args=['nopt', 'nbins', 'x1', 'y1', 'z1', 'w1', 'x2', 'y2', 'z2', 'w2', 'rbins', 'results']), Benchmark(name='Rambo', short_name='Rambo', relative_path='rambo', module_name='rambo', func_name='rambo', kind='microbenchmark', domain='Particles Physics', parameters=Parameters(S={'nevts': 32768, 'nout': 4}, M={'nevts': 8388608, 'nout': 4}, L={'nevts': 16777216, 'nout': 4}), init=Init(func_name='initialize', input_args=['nevts', 'nout'], output_args=['nevts', 'nout', 'C1', 'F1', 'Q1', 'output']), input_args=['nevts', 'nout', 'C1', 'F1', 'Q1', 'output'], array_args=['nevts', 'nout', 'C1', 'F1', 'Q1', 'output'], output_args=['nevts', 'nout', 'C1', 'F1', 'Q1', 'output'])], implementations=[Implementation(impl_postfix='numba_dpex_k', description='Numba-dpex kernel'), Implementation(impl_postfix='numba_dpex_p', description='Numba-dpex prange'), Implementation(impl_postfix='numba_dpex_n', description='Numba-dpex NumPy API'), Implementation(impl_postfix='dpnp', description='dpnp'), Implementation(impl_postfix='numpy', description='NumPy'), Implementation(impl_postfix='python', description='Python'), Implementation(impl_postfix='numba_n', description='Numba nopython'), Implementation(impl_postfix='numba_np', description='Numba nopython, Parallel=True'), Implementation(impl_postfix='numba_npr', description='Numba nopython, Parallel=True, prange'), Implementation(impl_postfix='sycl', description='DPC++ native ext.')])
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
