### PR TITLE
Adding initialization time to setup time

### DIFF
--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -105,7 +105,9 @@ def _exec(
     inputs = dict()
 
     with timer.timer() as t:
-        args = get_args()
+        args = get_args(
+            bench.get_data(preset=preset), bench.info["array_args"], fmwrk
+        )
 
     results_dict["setup_time"] = t.get_elapsed_time()
 
@@ -555,12 +557,7 @@ class BenchmarkRunner:
                         impl_postfix,
                         preset,
                         repeat,
-                        partial(
-                            _setup_func,
-                            self.bench.get_data(preset=self.preset),
-                            self.bench.info["array_args"],
-                            self.fmwrk,
-                        ),
+                        _setup_func,
                         results_dict,
                         copy_output,
                     ),


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

The "setup time" reported in the logs only includes the time to copy the input arguments. It does not include the time to initialize input data. As a result, there was a mismatch in the total dpbench execution time and the cumulative sum of the time spent is various stages of workload execution (like, setup time, warmup time, execution time and teardown time).

This PR add the initialization time to the setup time. Below is an example log from l2_norm workload's execution. It shows the log before counting initialization and after this PR. Notice the difference in setup time.

**Log from before counting initialization**

================ Benchmark l2_norm ========================
================ implementation numpy ========================
implementation: numpy
framework: numpy
framework version: 1.23.5
**setup time: 1864517574**
warmup time: 4000684183
teardown time: 507278175
max execution times: 3956269416
min execution times: 3956269416
median execution times: 3956269416.0
repeats: 1
preset: M
validated: FAILURE


**Log after counting before counting initialization - this PR**

================ Benchmark l2_norm ========================
================ implementation numpy ========================
implementation: numpy
framework: numpy
framework version: 1.23.5
**setup time: 9908348208**
warmup time: 3976763444
teardown time: 507553368
max execution times: 3953215762
min execution times: 3953215762
median execution times: 3953215762.0
repeats: 1
preset: M
validated: FAILURE


- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
