### PR TITLE
Add npbench integration

### DIFF
--- a/dpbench/config/benchmark.py
+++ b/dpbench/config/benchmark.py
@@ -73,7 +73,7 @@ class Benchmark:
     kind: str = ""
     domain: str = ""
     parameters: Presets = field(default_factory=Presets)
-    init: Init = field(default_factory=Init)
+    init: Init = None
     input_args: List[str] = field(default_factory=list)
     array_args: List[str] = field(default_factory=list)
     output_args: List[str] = field(default_factory=list)
@@ -81,17 +81,18 @@ class Benchmark:
 
     @staticmethod
     def from_dict(obj: Any) -> "Benchmark":
-        """Convert object into Benchamrk dataclass."""
+        """Convert object into Benchmark dataclass."""
         _name = str(obj.get("name") or "")
         _short_name = str(obj.get("short_name") or "")
         _relative_path = str(obj.get("relative_path") or "")
         _module_name = str(obj.get("module_name") or "")
-        _packge_path = str(obj.get("package_path") or "")
+        _package_path = str(obj.get("package_path") or "")
         _func_name = str(obj.get("func_name") or "")
         _kind = str(obj.get("kind") or "")
         _domain = str(obj.get("domain") or "")
         _parameters = Presets(obj.get("parameters"))
-        _init = Init.from_dict(obj.get("init"))
+        _init = obj.get("init")
+        _init = Init.from_dict(_init) if _init else None
         _input_args = obj.get("input_args") or []
         _array_args = obj.get("array_args") or []
         _output_args = obj.get("output_args") or []
@@ -101,7 +102,7 @@ class Benchmark:
             _short_name,
             _relative_path,
             _module_name,
-            _packge_path,
+            _package_path,
             _func_name,
             _kind,
             _domain,
@@ -112,16 +113,3 @@ class Benchmark:
             _output_args,
             _implementations,
         )
-
-    def __post_init__(self):
-        """Post initialization hook for dataclass. Not for direct use."""
-        if self.package_path == "":
-            self.package_path = f"dpbench.benchmarks.{self.module_name}"
-
-        if self.init.module_name == "":
-            self.init.module_name = f"{self.module_name}_initialize"
-
-        if self.init.package_path == "":
-            self.init.package_path = (
-                f"{self.package_path}.{self.init.module_name}"
-            )

--- a/dpbench/config/module.py
+++ b/dpbench/config/module.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module related configuration classes."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Module:
+    """Benchmark set configuration."""
+
+    benchmark_configs_path: str = ""
+    framework_configs_path: str = ""
+    impl_postfix_path: str = ""
+
+    benchmarks_module: str = ""
+    path: str = ""

--- a/dpbench/config/reader.py
+++ b/dpbench/config/reader.py
@@ -6,50 +6,118 @@
 
 import importlib
 import json
+import logging
 import os
+import pkgutil
+import re
+import sys
+from typing import Callable
 
-from .benchmark import Benchmark, BenchmarkImplementation
+from .benchmark import Benchmark, BenchmarkImplementation, Presets
 from .config import Config
 from .framework import Framework
 from .implementation_postfix import Implementation
+from .module import Module
 
 
-def read_configs(dirname: str = os.path.dirname(__file__)) -> Config:
+def read_configs(
+    benchmarks: list[str] = None,
+    postfixes: list[str] = None,
+) -> Config:
     """Read all configuration files and populate those settings into Config.
 
     Args:
-        dirname: Path to the directory with configuration files.
+        benchmarks: list of benchmarks to load. None means all.
+        postfixes: list of benchmark postfixes to load. None means all.
 
     Returns:
         Configuration object with populated configurations.
     """
     config: Config = Config([], [], [])
 
-    impl_postfix_file = os.path.join(dirname, "../configs/impl_postfix.json")
-    bench_info_dir = os.path.join(dirname, "../configs/bench_info")
-    framework_info_dir = os.path.join(dirname, "../configs/framework_info")
+    dirname: str = os.path.dirname(__file__)
 
-    read_benchmarks(config, bench_info_dir)
-    read_frameworks(config, framework_info_dir)
-    read_implementation_postfixes(config, impl_postfix_file)
+    modules: list[Module] = [
+        Module(
+            benchmark_configs_path=os.path.join(
+                dirname, "../configs/bench_info"
+            ),
+            benchmarks_module="dpbench.benchmarks",
+            framework_configs_path=os.path.join(
+                dirname, "../configs/framework_info"
+            ),
+            impl_postfix_path=os.path.join(
+                dirname, "../configs/impl_postfix.json"
+            ),
+        ),
+    ]
+
+    no_dpbench = os.getenv("NO_DPBENCH")
+    if no_dpbench:
+        modules[0].benchmark_configs_path = ""
+
+    npbench_root = os.getenv("NPBENCH_ROOT")
+    if npbench_root:
+        modules.append(
+            Module(
+                benchmark_configs_path=os.path.join(npbench_root, "bench_info"),
+                benchmarks_module="npbench.benchmarks",
+                path=npbench_root,
+            )
+        )
+
+    for mod in modules:
+        if mod.benchmark_configs_path != "":
+            read_benchmarks(
+                config,
+                mod.benchmark_configs_path,
+                parent_package=mod.benchmarks_module,
+                benchmarks=benchmarks,
+            )
+        if mod.framework_configs_path != "":
+            read_frameworks(config, mod.framework_configs_path)
+        if mod.impl_postfix_path != "":
+            read_implementation_postfixes(config, mod.impl_postfix_path)
+        if mod.path != "":
+            sys.path.append(mod.path)
 
     for benchmark in config.benchmarks:
-        read_benchmark_implementations(benchmark, config.implementations)
+        postfixes_tmp = postfixes
+        if postfixes_tmp is None:
+            postfixes_tmp = [impl.postfix for impl in config.implementations]
+        read_benchmark_implementations(
+            benchmark,
+            config.implementations,
+            postfixes=postfixes_tmp,
+        )
+
+    if npbench_root:
+        fix_npbench_configs(config.benchmarks)
 
     return config
 
 
-def read_benchmarks(config: Config, bench_info_dir: str):
+def read_benchmarks(
+    config: Config,
+    bench_info_dir: str,
+    parent_package: str = "dpbench.benchmarks",
+    benchmarks: list[str] = None,
+):
     """Read and populate benchmark configuration files.
 
     Args:
         config: Configuration object where settings should be populated.
         bench_info_dir: Path to the directory with configuration files.
+        parent_package: Package that contains benchmark packages.
+        benchmarks: list of benchmarks to load. None means all.
 
     Returns: nothing.
     """
     for bench_info_file in os.listdir(bench_info_dir):
         if not bench_info_file.endswith(".json"):
+            continue
+
+        if benchmarks and not bench_info_file[:-5] in benchmarks:
             continue
 
         bench_info_file = os.path.join(bench_info_dir, bench_info_file)
@@ -59,6 +127,13 @@ def read_benchmarks(config: Config, bench_info_dir: str):
 
         bench_info = json.loads(file_contents)
         benchmark = Benchmark.from_dict(bench_info.get("benchmark"))
+        if benchmark.package_path == "":
+            rel_path = benchmark.relative_path.replace("/", ".")
+
+            if benchmark.relative_path == "":
+                rel_path = benchmark.module_name
+
+            benchmark.package_path = f"{parent_package}.{rel_path}"
         config.benchmarks.append(benchmark)
 
 
@@ -109,14 +184,53 @@ def read_implementation_postfixes(
         config.implementations.append(implementation)
 
 
+def setup_init(config: Benchmark, modules: list[str]) -> None:
+    """Read and discover initialization module and function.
+
+    Args:
+        config: Benchmark configuration object where settings should be
+            populated.
+        modules: List of available modules for the benchmark to find init.
+
+    Returns: nothing.
+    """
+    if config.init is None:
+        return
+
+    init_module = None
+    if config.module_name in modules:
+        init_module = config.module_name
+    elif config.module_name + "_initialize" in modules:
+        init_module = config.module_name + "_initialize"
+
+    if init_module:
+        if config.init.module_name == "":
+            config.init.module_name = init_module
+        if config.init.package_path == "":
+            config.init.package_path = config.package_path + "." + init_module
+        if config.init.func_name == "":
+            config.init.func_name = "initialize"
+
+        impl_mod = importlib.import_module(config.init.package_path)
+
+        if not hasattr(impl_mod, config.init.func_name):
+            print(
+                f"WARNING: could not find init function for {config.module_name}"
+            )
+
+
 def read_benchmark_implementations(
-    config: Benchmark, implementations: Implementation
+    config: Benchmark,
+    known_implementations: list[Implementation],
+    postfixes: list[str] = None,
 ) -> None:
     """Read and discover implementation modules and functions.
 
     Args:
         config: Benchmark configuration object where settings should be
             populated.
+        postfixes: List of postfixes to import. Set it to None to import all
+            available implementations. It does not affect initialization import.
         implementations: Prepopulated list of implementations.
 
     Returns: nothing.
@@ -127,45 +241,56 @@ def read_benchmark_implementations(
     if config.implementations:
         return
 
-    mod = importlib.import_module("dpbench.benchmarks." + config.module_name)
+    try:
+        mod = importlib.import_module(config.package_path)
+    except ModuleNotFoundError:
+        logging.warning(f"Module not found: {config.package_path}")
+        return
 
     modules: list[str] = [
-        m
-        for m in mod.__loader__.get_resource_reader().contents()
-        if m.startswith(config.module_name)
+        name
+        for _, name, _ in pkgutil.iter_modules(
+            mod.__spec__.submodule_search_locations
+        )
     ]
+
+    setup_init(config, modules)
 
     for module in modules:
         postfix = ""
         module_name = ""
 
-        if module.endswith(".py"):
-            module_name = module[:-3]
-            postfix = module_name[len(config.module_name) + 1 :]
-        elif module.endswith("sycl_native_ext"):
+        if module.endswith("sycl_native_ext"):
             module_name = (
                 f"{module}.{config.module_name}_sycl._{config.module_name}_sycl"
             )
             postfix = "sycl"
+        else:
+            module_name = module
+            postfix = module[len(config.module_name) + 1 :]
 
-        if config.init.module_name.endswith(module_name):
+        if postfixes and postfix not in postfixes:
             continue
 
-        if postfix not in [impl.postfix for impl in implementations]:
-            raise RuntimeError(
-                f"Could not recognize postfix {postfix} as known postfix for"
-                + f" file {module} in {config.module_name}"
-            )
+        if config.init and config.init.module_name.endswith(module_name):
+            continue
+
+        if postfix not in [impl.postfix for impl in known_implementations]:
+            logging.warning(f"Skipping postfix: {module}")
+            continue
 
         func_name: str = None
-        package_path: str = (
-            f"dpbench.benchmarks.{config.module_name}.{module_name}"
-        )
+        package_path: str = f"{config.package_path}.{module_name}"
 
         try:
             impl_mod = importlib.import_module(package_path)
 
-            for func in [config.module_name, f"{config.module_name}_{postfix}"]:
+            for func in [
+                config.module_name,
+                f"{config.module_name}_{postfix}",
+                "kernel",
+                re.sub(r"[0-9]", "", config.module_name),
+            ]:
                 if hasattr(impl_mod, func):
                     func_name = func
                     break
@@ -180,3 +305,84 @@ def read_benchmark_implementations(
                 package_path=package_path,
             )
         )
+
+
+def get_benchmark_index(configs: list[Benchmark], module_name: str) -> int:
+    """Finds configuration index by module name."""
+    return next(
+        (
+            i
+            for i, config in enumerate(configs)
+            if config.module_name == module_name
+        ),
+        None,
+    )
+
+
+def fix_npbench_configs(configs: list[Benchmark]):
+    """Applies configuration fixes for some npbench benchmarks.
+
+    Fixes required due to the difference in framework implementations.
+    """
+    index = get_benchmark_index(configs, "mandelbrot1")
+    if index is not None:
+        configs[index] = modify_args(
+            configs[index], modifier=lambda s: s.lower()
+        )
+
+    index = get_benchmark_index(configs, "mandelbrot2")
+    if index is not None:
+        configs[index] = modify_args(
+            configs[index],
+            modifier=lambda s: "itermax" if s == "maxiter" else s.lower(),
+        )
+
+    index = get_benchmark_index(configs, "conv2d")
+    if index is not None:
+        config = configs[index]
+
+        config.module_name = "conv2d_bias"
+        configs[index] = config
+
+        for impl in config.implementations:
+            impl.func_name = "conv2d_bias"
+
+    index = get_benchmark_index(configs, "nbody")
+    if index is not None:
+        configs[index].output_args.append("pos")
+        configs[index].output_args.append("vel")
+
+    index = get_benchmark_index(configs, "scattering_self_energies")
+    if index is not None:
+        configs[index].output_args.append("Sigma")
+
+    index = get_benchmark_index(configs, "correlation")
+    if index is not None:
+        configs[index].output_args.append("data")
+
+    index = get_benchmark_index(configs, "doitgen")
+    if index is not None:
+        configs[index].output_args.append("A")
+
+
+def modify_args(config: Benchmark, modifier: Callable[[str], str]) -> Benchmark:
+    """Applies modifier to function argument names.
+
+    Current implementation applies modifier to
+      - all presets keys, not preset names;
+      - all input_args;
+      - all array_args;
+      - all output_args.
+    """
+    config.parameters = Presets(
+        {
+            preset: {modifier(k): v for k, v in parameters.items()}
+            for preset, parameters in config.parameters.items()
+        }
+    )
+
+    config.input_args = [modifier(arg) for arg in config.input_args]
+    config.array_args = [modifier(arg) for arg in config.array_args]
+    config.output_args = [modifier(arg) for arg in config.output_args]
+
+    return config

--- a/dpbench/infrastructure/dpcpp_framework.py
+++ b/dpbench/infrastructure/dpcpp_framework.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 import dpctl
 
-import dpbench.config as config
+import dpbench.config as cfg
 
 from .framework import Framework
 
@@ -15,7 +15,7 @@ from .framework import Framework
 class DpcppFramework(Framework):
     """A class for reading and processing framework information."""
 
-    def __init__(self, fname: str = None, config: config.Framework = None):
+    def __init__(self, fname: str = None, config: cfg.Framework = None):
         """Reads framework information.
         :param fname: The framework name.
         """

--- a/dpbench/infrastructure/reporter.py
+++ b/dpbench/infrastructure/reporter.py
@@ -43,6 +43,8 @@ def update_run_id(conn: sqlalchemy.Engine, run_id: Union[int, None]) -> int:
             f"WARNING: run_id was not provided, using the latest one {run_id}"
         )
 
+        return run_id
+
 
 def update_connection(
     results_db: Union[str, sqlalchemy.Engine] = "results.db",
@@ -102,6 +104,7 @@ def generate_summary(data: pd.DataFrame):
 def generate_impl_summary_report(
     results_db: Union[str, sqlalchemy.Engine] = "results.db",
     run_id: int = None,
+    postfixes: list[str] = None,
 ):
     """generate implementation summary report with status of each benchmark"""
     conn = update_connection(results_db=results_db)
@@ -117,8 +120,10 @@ def generate_impl_summary_report(
         dm.Result.problem_preset,
     ]
 
-    for _, row in legends.iterrows():
-        impl = row["impl_postfix"]
+    if postfixes is None:
+        postfixes = [row["impl_postfix"] for _, row in legends.iterrows()]
+
+    for impl in postfixes:
         columns.append(
             func.ifnull(
                 func.max(

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -11,7 +11,7 @@ import pkgutil
 from datetime import datetime
 
 import dpbench.benchmarks as dp_bms
-import dpbench.config as config
+import dpbench.config as cfg
 import dpbench.infrastructure as dpbi
 from dpbench.infrastructure.enums import ErrorCodes
 
@@ -43,22 +43,22 @@ def _print_results(result: dpbi.BenchmarkResults):
 
 
 def get_benchmark(
-    benchmark: config.Benchmark = None,
+    benchmark: cfg.Benchmark = None,
     benchmark_name: str = "",
-) -> config.Benchmark:
+) -> cfg.Benchmark:
     """Returns benchmark config if it is not none, otherwise returns benchmark
     config by name."""
     if benchmark is not None:
         return benchmark
 
     return next(
-        b for b in config.GLOBAL.benchmarks if b.module_name == benchmark_name
+        b for b in cfg.GLOBAL.benchmarks if b.module_name == benchmark_name
     )
 
 
 def run_benchmark(
     bname: str = "",
-    benchmark: config.Benchmark = None,
+    benchmark: cfg.Benchmark = None,
     implementation_postfix=None,
     preset="S",
     repeat=10,
@@ -135,8 +135,8 @@ def run_benchmarks(
     if run_id is None:
         run_id = dpbi.create_run(conn)
 
-    for b in config.GLOBAL.benchmarks:
-        for impl in config.GLOBAL.implementations:
+    for b in cfg.GLOBAL.benchmarks:
+        for impl in cfg.GLOBAL.implementations:
             run_benchmark(
                 benchmark=b,
                 implementation_postfix=impl.postfix,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

Add two new environment variables:
`NPBENCH_ROOT` - path to npbench root. if provided `dpbench` will run `npbench` benchmark using it's own framework.
`NO_DPBENCH` - if provided, `dpbench` benchmarks won't be executed. It is useful if you wanna just run `npbench` benchmarks.

Add support for autodiscover of implementation function: it is possible to name implementation function with `kernel`.

Add support for benchmarks without initialize methods.

Fix report with no `run_id` provided.

Add support for report to show just few postfix columns, not all. E.g.:
```bash
python -c "import dpbench; dpbench.infrastructure.generate_impl_summary_report(postfixes=['numpy','numba_n','numba_np','numba_npr'])"
```

To generate report:
```bash
NPBENCH_ROOT=<local path to npbench repo> python -c "import dpbench; dpbench.run_benchmarks()"
```

```
Report for 2023-04-19 12:04:03 run
==================================
Legend
======
   impl_postfix                            description
0  numba_dpex_k  Numba-dpex kernel
1  numba_dpex_p  Numba-dpex prange
2  numba_dpex_n  Numba-dpex NumPy API
3  dpnp          dpnp
4  numpy         NumPy
5  python        Python
6  numba_n       Numba nopython
7  numba_np      Numba nopython, Parallel=True
8  numba_npr     Numba nopython, Parallel=True, prange
9  sycl          DPC++ native ext.

Summary of current implementation
=================================
   input_size                 benchmark problem_preset    numpy            numba_n           numba_np          numba_npr
0          0B                       adi              S  Success            Success            Success      Unimplemented
1          0B              arc_distance              S  Success            Success            Success      Unimplemented
2          0B                      atax              S  Success            Success            Success      Unimplemented
3         6MB              azimint_hist              S  Success            Success            Success  Failed Validation
4         6MB             azimint_naive              S  Success            Success            Success            Success
5          0B                      bicg              S  Success            Success            Success      Unimplemented
6          0B               cavity_flow              S  Success            Success      Unimplemented      Unimplemented
7          0B              channel_flow              S  Success            Success            Success      Unimplemented
8        78KB                  cholesky              S  Success            Success      Unimplemented            Success
9          0B                 cholesky2              S  Success            Success            Success      Unimplemented
10         0B                   compute              S  Success            Success            Success      Unimplemented
11      234KB          contour_integral              S  Success            Success   Failed Execution   Failed Execution
12       96KB               conv2d_bias              S  Success            Success            Success            Success
13        2MB               correlation              S  Success            Success   Failed Execution   Failed Execution
14        2MB                covariance              S  Success            Success   Failed Execution   Failed Execution
15         0B                     crc16              S  Success            Success            Success      Unimplemented
16         0B                   deriche              S  Success            Success            Success      Unimplemented
17         0B                   doitgen              S  Success            Success      Unimplemented      Unimplemented
18         0B                    durbin              S  Success            Success  Failed Validation      Unimplemented
19         0B                   fdtd_2d              S  Success            Success            Success      Unimplemented
20      156KB            floyd_warshall              S  Success            Success   Failed Execution            Success
21         0B                      gemm              S  Success            Success            Success      Unimplemented
22         0B                    gemver              S  Success            Success            Success      Unimplemented
23         0B                   gesummv              S  Success            Success            Success      Unimplemented
24       30MB                   go_fast              S  Success            Success            Success            Success
25         0B               gramschmidt              S  Success            Success            Success      Unimplemented
26         0B                     hdiff              S  Success            Success            Success      Unimplemented
27         0B                   heat_3d              S  Success            Success            Success      Unimplemented
28         0B                 jacobi_1d              S  Success            Success            Success      Unimplemented
29         0B                 jacobi_2d              S  Success            Success            Success      Unimplemented
30         0B                      k2mm              S  Success            Success            Success      Unimplemented
31         0B                      k3mm              S  Success            Success            Success      Unimplemented
32         0B                        lu              S  Success            Success            Success      Unimplemented
33         0B                    ludcmp              S  Success            Success            Success      Unimplemented
34         0B               mandelbrot1              S  Success            Success            Success            Success
35         0B               mandelbrot2              S  Success            Success      Unimplemented      Unimplemented
36      244MB                       mlp              S  Success  Failed Validation  Failed Validation  Failed Validation
37         0B                       mvt              S  Success            Success            Success      Unimplemented
38         0B                     nbody              S  Success            Success      Unimplemented      Unimplemented
39         0B                  nussinov              S  Success            Success            Success      Unimplemented
40       19KB  scattering_self_energies              S  Success            Success      Unimplemented            Success
41         0B                 seidel_2d              S  Success            Success  Failed Validation      Unimplemented
42       16MB                   softmax              S  Success            Success            Success            Success
43      144KB                      spmv              S  Success            Success            Success            Success
44        1MB              stockham_fft              S  Success            Success   Failed Execution            Success
45       43KB                      symm              S  Success            Success      Unimplemented            Success
46         0B                     syr2k              S  Success            Success      Unimplemented      Unimplemented
47         0B                      syrk              S  Success            Success      Unimplemented      Unimplemented
48         0B                   trisolv              S  Success            Success            Success      Unimplemented
49       73KB                      trmm              S  Success            Success      Unimplemented            Success
50         0B                      vadv              S  Success            Success            Success      Unimplemented
```

It may be more execution problems if `numba_dpex` was imported, cause it overwrites some numba functions. E.g.: `mandelbrot1` using complex numbers, that are not supported by `dpnp`.


Failed Validation problems:
- `seidel_2d` does not fail if run via `run_benchmark` but fails when run with other benchs in `run_benchmarks()`
- `mlp` fails because of wrong implementation of `ndarray.max()` method. It does not compile in numba.
- `durbin`, `azimint_hist` fails in npbench as well

Failed Execution problems:
- `contour_integral`, `correlation`, `covariance` fails the same way as in `npbench`
- `floyd_warshall`, `stockham_fft` causes segmentation fall in `npbench`

MLP fix:
```python
    for i in range(x.shape[0]):
        tmp_max[i, 0] = np.max(x[i])
```
instead of
```python
    for i in range(x.shape[1]):
        tmp_max[:, 0] = np.max(x[:, i])
```



- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
