### PR TITLE
Removing unnecessary outputs from blackscholes and rambo initialization

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_initialize.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_initialize.py
@@ -26,4 +26,4 @@ def initialize(nopt, seed):
     call = np.zeros(nopt, dtype=dtype)
     put = -np.ones(nopt, dtype=dtype)
 
-    return (nopt, price, strike, t, rate, volatility, call, put)
+    return (price, strike, t, rate, volatility, call, put)

--- a/dpbench/benchmarks/rambo/rambo_initialize.py
+++ b/dpbench/benchmarks/rambo/rambo_initialize.py
@@ -17,11 +17,4 @@ def initialize(nevts, nout):
             F1[i, j] = np.random.rand()
             Q1[i, j] = np.random.rand() * np.random.rand()
 
-    return (
-        nevts,
-        nout,
-        C1,
-        F1,
-        Q1,
-        np.empty((nevts, nout, 4)),
-    )
+    return (C1, F1, Q1, np.empty((nevts, nout, 4)))

--- a/dpbench/configs/bench_info/black_scholes.toml
+++ b/dpbench/configs/bench_info/black_scholes.toml
@@ -51,7 +51,6 @@ input_args = [
     "seed",
 ]
 output_args = [
-    "nopt",
     "price",
     "strike",
     "t",

--- a/dpbench/configs/bench_info/rambo.toml
+++ b/dpbench/configs/bench_info/rambo.toml
@@ -47,8 +47,6 @@ input_args = [
     "nout",
 ]
 output_args = [
-    "nevts",
-    "nout",
     "C1",
     "F1",
     "Q1",


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Rambo and Blackscholes initialization functions are returning the size data that are passed into to the initialization, which is unnecessary. The size data is set in the parameters field in the configuration files. Removing these unnecessary outputs in this PR.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
