### PR TITLE
Fix mlp numba parallel benchmark

### DIFF
--- a/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_np.py
+++ b/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_np.py
@@ -18,8 +18,8 @@ def softmax(x):
     new_shape = (x.shape[0], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
     tmp_max = np.empty(new_shape, dtype=x.dtype)
-    for i in range(x.shape[1]):
-        tmp_max[:, 0] = np.max(x[:, i])
+    for i in range(x.shape[0]):
+        tmp_max[i, 0] = np.max(x[i])
     tmp_out = np.exp(x - tmp_max)
     # tmp_sum = np.sum(tmp_out, axis=-1, keepdims=True)
     tmp_sum = np.reshape(np.sum(tmp_out, axis=-1), new_shape)

--- a/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_npr.py
+++ b/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_npr.py
@@ -18,8 +18,8 @@ def softmax(x):
     new_shape = (x.shape[0], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
     tmp_max = np.empty(new_shape, dtype=x.dtype)
-    for i in nb.prange(x.shape[1]):
-        tmp_max[:, 0] = np.max(x[:, i])
+    for i in nb.prange(x.shape[0]):
+        tmp_max[i, 0] = np.max(x[i])
     tmp_out = np.exp(x - tmp_max)
     # tmp_sum = np.sum(tmp_out, axis=-1, keepdims=True)
     tmp_sum = np.reshape(np.sum(tmp_out, axis=-1), new_shape)


### PR DESCRIPTION
There was a mistake while reimplementing `np.max(x, axis=-1, keepdims=True)`. I've partially fixed it in integration PR. https://github.com/IntelPython/dpbench/pull/219

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
