### PR TITLE
Fix npbench configurations

### DIFF
--- a/dpbench/configs/bench_info/npbench/conv2d_bias.toml
+++ b/dpbench/configs/bench_info/npbench/conv2d_bias.toml
@@ -7,7 +7,7 @@
 name = "Conv2D with Bias"
 short_name = "conv2d"
 relative_path = "deep_learning/conv2d_bias"
-module_name = "conv2d"
+module_name = "conv2d_bias"
 func_name = "conv2d_bias"
 kind = "microbench"
 domain = "Learning"

--- a/dpbench/configs/bench_info/npbench/mandelbrot1.toml
+++ b/dpbench/configs/bench_info/npbench/mandelbrot1.toml
@@ -18,8 +18,8 @@ input_args = [
     "xmax",
     "ymin",
     "ymax",
-    "XN",
-    "YN",
+    "xn",
+    "yn",
     "maxiter",
     "horizon",
 ]
@@ -30,39 +30,39 @@ norm_error = 0.001
 [benchmark.parameters.S]
 xmin = -1.75
 xmax = 0.25
-XN = 125
+xn = 125
 ymin = -1.0
 ymax = 1.0
-YN = 125
+yn = 125
 maxiter = 60
 horizon = 2.0
 
 [benchmark.parameters.M]
 xmin = -1.75
 xmax = 0.25
-XN = 250
+xn = 250
 ymin = -1.0
 ymax = 1.0
-YN = 250
+yn = 250
 maxiter = 150
 horizon = 2.0
 
 [benchmark.parameters.L]
 xmin = -2.0
 xmax = 0.5
-XN = 833
+xn = 833
 ymin = -1.25
 ymax = 1.25
-YN = 833
+yn = 833
 maxiter = 200
 horizon = 2.0
 
 [benchmark.parameters.paper]
 xmin = -2.25
 xmax = 0.75
-XN = 1000
+xn = 1000
 ymin = -1.25
 ymax = 1.25
-YN = 1000
+yn = 1000
 maxiter = 200
 horizon = 2.0

--- a/dpbench/configs/bench_info/npbench/mandelbrot2.toml
+++ b/dpbench/configs/bench_info/npbench/mandelbrot2.toml
@@ -18,9 +18,9 @@ input_args = [
     "xmax",
     "ymin",
     "ymax",
-    "XN",
-    "YN",
-    "maxiter",
+    "xn",
+    "yn",
+    "itermax",
     "horizon",
 ]
 array_args = []
@@ -30,39 +30,39 @@ norm_error = 0.001
 [benchmark.parameters.S]
 xmin = -2.0
 xmax = 0.5
-XN = 200
+xn = 200
 ymin = -1.25
 ymax = 1.25
-YN = 200
-maxiter = 40
+yn = 200
+itermax = 40
 horizon = 2.0
 
 [benchmark.parameters.M]
 xmin = -2.0
 xmax = 0.5
-XN = 500
+xn = 500
 ymin = -1.25
 ymax = 1.25
-YN = 500
-maxiter = 80
+yn = 500
+itermax = 80
 horizon = 2.0
 
 [benchmark.parameters.L]
 xmin = -2.25
 xmax = 0.75
-XN = 1000
+xn = 1000
 ymin = -1.5
 ymax = 1.5
-YN = 1000
-maxiter = 100
+yn = 1000
+itermax = 100
 horizon = 2.0
 
 [benchmark.parameters.paper]
 xmin = -2.25
 xmax = 0.75
-XN = 1000
+xn = 1000
 ymin = -1.25
 ymax = 1.25
-YN = 1000
-maxiter = 200
+yn = 1000
+itermax = 200
 horizon = 2.0

--- a/dpbench/configs/bench_info/npbench/nbody.toml
+++ b/dpbench/configs/bench_info/npbench/nbody.toml
@@ -28,7 +28,10 @@ array_args = [
     "pos",
     "vel",
 ]
-output_args = []
+output_args = [
+    "pos",
+    "vel",
+]
 norm_error = 0.1
 
 [benchmark.parameters.S]

--- a/dpbench/configs/bench_info/npbench/scattering_self_energies.toml
+++ b/dpbench/configs/bench_info/npbench/scattering_self_energies.toml
@@ -26,7 +26,9 @@ array_args = [
     "D",
     "Sigma",
 ]
-output_args = []
+output_args = [
+    "Sigma",
+]
 
 [benchmark.parameters.S]
 Nkz = 2

--- a/dpbench/configs/bench_info/polybench/datamining/correlation.toml
+++ b/dpbench/configs/bench_info/polybench/datamining/correlation.toml
@@ -21,7 +21,9 @@ input_args = [
 array_args = [
     "data",
 ]
-output_args = []
+output_args = [
+    "data",
+]
 
 [benchmark.parameters.S]
 M = 500

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/doitgen.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/doitgen.toml
@@ -24,7 +24,9 @@ array_args = [
     "A",
     "C4",
 ]
-output_args = []
+output_args = [
+    "A",
+]
 
 [benchmark.parameters.S]
 NR = 60


### PR DESCRIPTION
Since npbench and polybench are now in the source tree we can update configurations directly, rather than apply fixes programmatically.

It adds feature to read benchmark implementations and initialization that starts with short_name.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
