### PR TITLE
Add fail check

### DIFF
--- a/dpbench/config/benchmark.py
+++ b/dpbench/config/benchmark.py
@@ -88,6 +88,7 @@ class Benchmark:
     array_args: List[str] = field(default_factory=list)
     output_args: List[str] = field(default_factory=list)
     implementations: List[BenchmarkImplementation] = field(default_factory=list)
+    expected_failure_implementations: List[str] = field(default_factory=list)
 
     @staticmethod
     def from_dict(obj: Any) -> "Benchmark":
@@ -107,6 +108,9 @@ class Benchmark:
         _array_args = obj.get("array_args") or []
         _output_args = obj.get("output_args") or []
         _implementations = obj.get("implementations") or []
+        _expected_failure_implementations = (
+            obj.get("expected_failure_implementations") or []
+        )
         return Benchmark(
             _name,
             _short_name,
@@ -122,4 +126,5 @@ class Benchmark:
             _array_args,
             _output_args,
             _implementations,
+            _expected_failure_implementations,
         )

--- a/dpbench/configs/bench_info/dbscan.toml
+++ b/dpbench/configs/bench_info/dbscan.toml
@@ -20,6 +20,7 @@ input_args = [
 array_args = [
     "data",
 ]
+expected_failure_implementations = ["sycl"]
 
 [benchmark.parameters.S]
 n_samples = 1024

--- a/dpbench/configs/bench_info/gpairs.toml
+++ b/dpbench/configs/bench_info/gpairs.toml
@@ -39,6 +39,7 @@ array_args = [
 output_args = [
     "results",
 ]
+expected_failure_implementations = ["numba_dpex_k"]
 
 [benchmark.parameters.S]
 nopt = 128

--- a/dpbench/configs/bench_info/knn.toml
+++ b/dpbench/configs/bench_info/knn.toml
@@ -32,6 +32,7 @@ array_args = [
 output_args = [
     "predictions",
 ]
+expected_failure_implementations = ["numba_dpex_p"]
 
 [benchmark.parameters.S]
 test_size = 1024

--- a/dpbench/configs/bench_info/l2_norm.toml
+++ b/dpbench/configs/bench_info/l2_norm.toml
@@ -21,6 +21,7 @@ array_args = [
 output_args = [
     "d",
 ]
+expected_failure_implementations = ["dpnp", "numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 32768

--- a/dpbench/configs/bench_info/npbench/azimint_hist.toml
+++ b/dpbench/configs/bench_info/npbench/azimint_hist.toml
@@ -23,6 +23,7 @@ array_args = [
     "radius",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 400000

--- a/dpbench/configs/bench_info/npbench/azimint_naive.toml
+++ b/dpbench/configs/bench_info/npbench/azimint_naive.toml
@@ -23,6 +23,7 @@ array_args = [
     "radius",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 400000

--- a/dpbench/configs/bench_info/npbench/cavity_flow.toml
+++ b/dpbench/configs/bench_info/npbench/cavity_flow.toml
@@ -38,6 +38,7 @@ output_args = [
     "v",
     "p",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 ny = 61

--- a/dpbench/configs/bench_info/npbench/channel_flow.toml
+++ b/dpbench/configs/bench_info/npbench/channel_flow.toml
@@ -37,6 +37,7 @@ output_args = [
     "v",
     "p",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 ny = 61

--- a/dpbench/configs/bench_info/npbench/compute.toml
+++ b/dpbench/configs/bench_info/npbench/compute.toml
@@ -26,6 +26,7 @@ array_args = [
     "array_2",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 2000

--- a/dpbench/configs/bench_info/npbench/contour_integral.toml
+++ b/dpbench/configs/bench_info/npbench/contour_integral.toml
@@ -26,6 +26,7 @@ array_args = [
     "Y",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 NR = 50

--- a/dpbench/configs/bench_info/npbench/conv2d_bias.toml
+++ b/dpbench/configs/bench_info/npbench/conv2d_bias.toml
@@ -23,6 +23,7 @@ array_args = [
     "bias",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 8

--- a/dpbench/configs/bench_info/npbench/crc16.toml
+++ b/dpbench/configs/bench_info/npbench/crc16.toml
@@ -20,6 +20,7 @@ array_args = [
     "data",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 1600

--- a/dpbench/configs/bench_info/npbench/hdiff.toml
+++ b/dpbench/configs/bench_info/npbench/hdiff.toml
@@ -27,6 +27,7 @@ array_args = [
 output_args = [
     "out_field",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 I = 64

--- a/dpbench/configs/bench_info/npbench/mandelbrot2.toml
+++ b/dpbench/configs/bench_info/npbench/mandelbrot2.toml
@@ -26,6 +26,7 @@ input_args = [
 array_args = []
 output_args = []
 norm_error = 0.001
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 xmin = -2.0

--- a/dpbench/configs/bench_info/npbench/mlp.toml
+++ b/dpbench/configs/bench_info/npbench/mlp.toml
@@ -31,6 +31,7 @@ array_args = [
     "b3",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 C_in = 3

--- a/dpbench/configs/bench_info/npbench/nbody.toml
+++ b/dpbench/configs/bench_info/npbench/nbody.toml
@@ -33,6 +33,7 @@ output_args = [
     "vel",
 ]
 norm_error = 0.1
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 25

--- a/dpbench/configs/bench_info/npbench/scattering_self_energies.toml
+++ b/dpbench/configs/bench_info/npbench/scattering_self_energies.toml
@@ -29,6 +29,7 @@ array_args = [
 output_args = [
     "Sigma",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 Nkz = 2

--- a/dpbench/configs/bench_info/npbench/softmax.toml
+++ b/dpbench/configs/bench_info/npbench/softmax.toml
@@ -19,6 +19,7 @@ array_args = [
     "x",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 16

--- a/dpbench/configs/bench_info/npbench/spmv.toml
+++ b/dpbench/configs/bench_info/npbench/spmv.toml
@@ -25,6 +25,7 @@ array_args = [
     "x",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 4096

--- a/dpbench/configs/bench_info/npbench/stockham_fft.toml
+++ b/dpbench/configs/bench_info/npbench/stockham_fft.toml
@@ -26,6 +26,7 @@ array_args = [
 output_args = [
     "y",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 R = 2

--- a/dpbench/configs/bench_info/npbench/vadv.toml
+++ b/dpbench/configs/bench_info/npbench/vadv.toml
@@ -32,6 +32,7 @@ array_args = [
 output_args = [
     "utens_stage",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 I = 60

--- a/dpbench/configs/bench_info/pairwise_distance.toml
+++ b/dpbench/configs/bench_info/pairwise_distance.toml
@@ -23,6 +23,7 @@ array_args = [
 output_args = [
     "D",
 ]
+expected_failure_implementations = ["dpnp", "numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 1024

--- a/dpbench/configs/bench_info/pca.toml
+++ b/dpbench/configs/bench_info/pca.toml
@@ -21,6 +21,7 @@ output_args = [
     "evalues",
     "evectors",
 ]
+expected_failure_implementations = ["dpnp", "numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 1024

--- a/dpbench/configs/bench_info/polybench/datamining/correlation.toml
+++ b/dpbench/configs/bench_info/polybench/datamining/correlation.toml
@@ -24,6 +24,7 @@ array_args = [
 output_args = [
     "data",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 500

--- a/dpbench/configs/bench_info/polybench/datamining/covariance.toml
+++ b/dpbench/configs/bench_info/polybench/datamining/covariance.toml
@@ -22,6 +22,7 @@ array_args = [
     "data",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 500

--- a/dpbench/configs/bench_info/polybench/linear-algebra/blas/gemm.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/blas/gemm.toml
@@ -28,6 +28,7 @@ array_args = [
 output_args = [
     "C",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 NI = 1000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/blas/gemver.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/blas/gemver.toml
@@ -42,6 +42,7 @@ output_args = [
     "w",
     "x",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 1000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/blas/gesummv.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/blas/gesummv.toml
@@ -26,6 +26,7 @@ array_args = [
     "x",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 2000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/blas/symm.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/blas/symm.toml
@@ -28,6 +28,7 @@ array_args = [
 output_args = [
     "C",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 40

--- a/dpbench/configs/bench_info/polybench/linear-algebra/blas/trmm.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/blas/trmm.toml
@@ -25,6 +25,7 @@ array_args = [
 output_args = [
     "B",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 65

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/atax.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/atax.toml
@@ -22,6 +22,7 @@ array_args = [
     "x",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 4000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/bicg.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/bicg.toml
@@ -24,6 +24,7 @@ array_args = [
     "r",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 M = 4000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/doitgen.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/doitgen.toml
@@ -27,6 +27,7 @@ array_args = [
 output_args = [
     "A",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 NR = 60

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/k2mm.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/k2mm.toml
@@ -30,6 +30,7 @@ array_args = [
 output_args = [
     "D",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 NI = 800

--- a/dpbench/configs/bench_info/polybench/linear-algebra/kernels/mvt.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/kernels/mvt.toml
@@ -31,6 +31,7 @@ output_args = [
     "x1",
     "x2",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 5500

--- a/dpbench/configs/bench_info/polybench/linear-algebra/solvers/cholesky.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/solvers/cholesky.toml
@@ -22,6 +22,7 @@ array_args = [
 output_args = [
     "A",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 100

--- a/dpbench/configs/bench_info/polybench/linear-algebra/solvers/durbin.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/solvers/durbin.toml
@@ -22,6 +22,7 @@ array_args = [
 output_args = []
 rtol = 0.001
 atol = 0.001
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 1000

--- a/dpbench/configs/bench_info/polybench/linear-algebra/solvers/lu.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/solvers/lu.toml
@@ -22,6 +22,7 @@ array_args = [
 output_args = [
     "A",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 60

--- a/dpbench/configs/bench_info/polybench/linear-algebra/solvers/ludcmp.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/solvers/ludcmp.toml
@@ -24,6 +24,7 @@ array_args = [
 output_args = [
     "A",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 60

--- a/dpbench/configs/bench_info/polybench/linear-algebra/solvers/trisolv.toml
+++ b/dpbench/configs/bench_info/polybench/linear-algebra/solvers/trisolv.toml
@@ -26,6 +26,7 @@ array_args = [
 output_args = [
     "b",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 2000

--- a/dpbench/configs/bench_info/polybench/medley/deriche.toml
+++ b/dpbench/configs/bench_info/polybench/medley/deriche.toml
@@ -21,6 +21,7 @@ array_args = [
     "imgIn",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 W = 400

--- a/dpbench/configs/bench_info/polybench/medley/floyd_warshall.toml
+++ b/dpbench/configs/bench_info/polybench/medley/floyd_warshall.toml
@@ -22,6 +22,7 @@ array_args = [
 output_args = [
     "path",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 200

--- a/dpbench/configs/bench_info/polybench/medley/nussinov.toml
+++ b/dpbench/configs/bench_info/polybench/medley/nussinov.toml
@@ -21,6 +21,7 @@ array_args = [
     "seq",
 ]
 output_args = []
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 N = 40

--- a/dpbench/configs/bench_info/polybench/stencils/fdtd_2d.toml
+++ b/dpbench/configs/bench_info/polybench/stencils/fdtd_2d.toml
@@ -31,6 +31,7 @@ output_args = [
     "ey",
     "hz",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 TMAX = 20

--- a/dpbench/configs/bench_info/polybench/stencils/seidel_2d.toml
+++ b/dpbench/configs/bench_info/polybench/stencils/seidel_2d.toml
@@ -24,6 +24,7 @@ array_args = [
 output_args = [
     "A",
 ]
+expected_failure_implementations = ["dpnp"]
 
 [benchmark.parameters.S]
 TSTEPS = 8

--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -17,7 +17,11 @@ from .dpnp_framework import DpnpFramework
 from .framework import Framework
 from .numba_dpex_framework import NumbaDpexFramework
 from .numba_framework import NumbaFramework
-from .reporter import generate_impl_summary_report, generate_performance_report
+from .reporter import (
+    generate_impl_summary_report,
+    generate_performance_report,
+    get_unexpected_failures,
+)
 from .utilities import validate
 
 __all__ = [
@@ -37,5 +41,6 @@ __all__ = [
     "store_results",
     "generate_impl_summary_report",
     "generate_performance_report",
+    "get_unexpected_failures",
     "validate",
 ]

--- a/dpbench/runner.py
+++ b/dpbench/runner.py
@@ -216,3 +216,10 @@ def run_benchmarks(
             implementations=implementations,
             headless=True,
         )
+
+        unexpected_failures = dpbi.get_unexpected_failures(conn, run_id=run_id)
+
+        if len(unexpected_failures) > 0:
+            raise ValueError(
+                f"Unexpected benchmark implementations failed: {unexpected_failures}.",
+            )

--- a/scripts/set_expected_failure.py
+++ b/scripts/set_expected_failure.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Set expected failure to benchmark configuration based on results.
+
+This script requires tomlkit library installed.
+"""
+
+import argparse
+import os
+
+import tomlkit
+
+from dpbench.infrastructure.reporter import get_failures_from_results
+
+dirname: str = os.path.dirname(__file__)
+
+parser = argparse.ArgumentParser(
+    description="Set expected failure for benchmarks based on the run.",
+)
+
+parser.add_argument(
+    "dirname", default=os.path.join(dirname, "../dpbench/configs/bench_info")
+)
+
+parser.add_argument(
+    "-r",
+    "--run_id",
+    default=1,
+)
+
+parser.add_argument(
+    "-n",
+    "--no-remove",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+)
+
+args = parser.parse_args()
+
+failures_list = get_failures_from_results(run_id=args.run_id)
+failures = dict()
+for benchmark, implementation in failures_list:
+    if not failures.get(benchmark):
+        failures[benchmark] = []
+    failures[benchmark] += [implementation]
+
+for benchmark, implementation in failures_list:
+    failures[benchmark].sort()
+
+for root, _, files in os.walk(args.dirname):
+    for file in files:
+        bench_info_file = os.path.join(root, file)
+        if bench_info_file[-5:] != ".toml":
+            continue
+
+        with open(bench_info_file) as file:
+            file_contents = file.read()
+
+        bench_info = tomlkit.loads(file_contents)
+        bench = bench_info["benchmark"]["module_name"]
+
+        if (
+            not args.no_remove
+            and failures.get(bench, None) is None
+            and bench_info["benchmark"].get(
+                "expected_failure_implementations", None
+            )
+            is not None
+        ):
+            bench_info["benchmark"].pop("expected_failure_implementations")
+
+        if failures.get(bench, None) is not None:
+            bench_info["benchmark"][
+                "expected_failure_implementations"
+            ] = failures[bench]
+
+        file_contents = tomlkit.dumps(bench_info)
+
+        with open(bench_info_file, "w") as file:
+            file.write(file_contents)


### PR DESCRIPTION
Add fail check for the `run_benchmarks` so that it returns status code 1, if unexpected benchmark failed.

Closes: https://github.com/IntelPython/dpbench/issues/234

What this PR does - it prevents new `Failed Execution` and `Execution Timeout` appearance without mentioning it explicitly in the configuration. Both of these errors treated the same. It does not check unimplemented status because it is obvious from the PR (file got deleted). 
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
