### PR TITLE
Fix dbscan sycl failure

### DIFF
--- a/dpbench/configs/bench_info/dbscan.toml
+++ b/dpbench/configs/bench_info/dbscan.toml
@@ -20,7 +20,6 @@ input_args = [
 array_args = [
     "data",
 ]
-expected_failure_implementations = ["sycl"]
 
 [benchmark.parameters.S]
 n_samples = 1024

--- a/dpbench/infrastructure/frameworks/dpcpp_framework.py
+++ b/dpbench/infrastructure/frameworks/dpcpp_framework.py
@@ -76,9 +76,15 @@ class DpcppFramework(Framework):
         any array created by the framework possibly on
         a device memory domain."""
 
-        import dpctl.tensor as dpt
+        def _copy_from_func(usm_array):
+            import dpctl.tensor as dpt
 
-        return dpt.asnumpy
+            if isinstance(usm_array, dpt.usm_ndarray):
+                return dpt.asnumpy(usm_array)
+            else:
+                return usm_array
+
+        return _copy_from_func
 
     def version(self) -> str:
         """Returns the framework version."""


### PR DESCRIPTION
DBSCAN sycl implementation had a failure because a scalar was being passed to the `copy_to_func` which copies output from framework specific type to numpy. `dpctl.tensor.asnumpy` failed when supplied a scalar argument.

Added a check to only pass `dpctl.tensor.usm_ndarray` types to `dpctl.tensor.asnumpy`.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
