### PR TITLE
WIP: Add proper way to get sycl version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,5 +147,3 @@ dmypy.json
 
 # VSCode local files
 .vscode
-
-dpbench/configs/framework_info/dpcpp_version.toml

--- a/dpbench/benchmarks/CMakeLists.txt
+++ b/dpbench/benchmarks/CMakeLists.txt
@@ -10,13 +10,3 @@ add_subdirectory(kmeans)
 add_subdirectory(knn)
 add_subdirectory(gpairs)
 add_subdirectory(dbscan)
-
-# generate dpcpp version into json
-file(WRITE
-    ${CMAKE_SOURCE_DIR}/dpbench/configs/framework_info/dpcpp_version.json
-    "{\"dpcpp_version\" :"
-    " \""
-    ${CMAKE_CXX_COMPILER_ID}
-    " "
-    ${CMAKE_CXX_COMPILER_VERSION}
-    "\"}")

--- a/dpbench/config/framework.py
+++ b/dpbench/config/framework.py
@@ -20,7 +20,6 @@ class Framework:
     class_: str
     arch: str
     sycl_device: str
-    dpcpp_version: str
     postfixes: List[Implementation] = field(default_factory=list)
 
     @staticmethod
@@ -32,7 +31,6 @@ class Framework:
         _class = str(obj.get("class") or "")
         _arch = str(obj.get("arch") or "")
         _sycl_device = str(obj.get("sycl_device") or "")
-        _dpcpp_version = str(obj.get("dpcpp_version") or "")
         _postfixes = obj.get("postfixes") or []
         for i, _postfix in enumerate(_postfixes):
             _postfixes[i] = Implementation.from_dict(_postfix)
@@ -44,6 +42,5 @@ class Framework:
             _class,
             _arch,
             _sycl_device,
-            _dpcpp_version,
             _postfixes,
         )

--- a/dpbench/configs/framework_info/dpcpp.toml
+++ b/dpbench/configs/framework_info/dpcpp.toml
@@ -10,7 +10,6 @@ postfix = "dpcpp"
 class = "DpcppFramework"
 arch = "cpu"
 sycl_device = "cpu"
-dpcpp_version = "IntelLLVM 2023.1.0"
 
 [[framework.postfixes]]
 impl_postfix = "sycl"

--- a/dpbench/infrastructure/frameworks/dpcpp_framework.py
+++ b/dpbench/infrastructure/frameworks/dpcpp_framework.py
@@ -88,5 +88,13 @@ class DpcppFramework(Framework):
 
     def version(self) -> str:
         """Returns the framework version."""
-        # hack the dpcpp version, need validate dpcpp available first
-        return self.info.dpcpp_version
+        import os
+        import re
+
+        version = os.popen("icpx --version").read().split("\n", 1)[0]
+
+        version = re.sub(
+            r"Intel.* ([0-9\.]+)( \([0-9\.]+\))?", r"IntelLLVM \g<1>", version
+        )
+
+        return version


### PR DESCRIPTION
Adds sycl version from `ipcx --verison` instead of cmake.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
