### PR TITLE
Add numba_dpex_p implementation for poly/np-bench

### DIFF
--- a/dpbench/benchmarks/npbench/azimint_hist/azimint_hist_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/azimint_hist/azimint_hist_numba_dpex_p.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2014 Jérôme Kieffer et al.
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Jérôme Kieffer and Giannis Ashiotis. Pyfai: a python library for
+high performance azimuthal integration on gpu, 2014. In Proceedings of the
+7th European Conference on Python in Science (EuroSciPy 2014).
+"""
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def get_bin_edges_prange(a, bins):
+    bin_edges = np.zeros((bins + 1,), dtype=np.float64)
+    a_min = a.min()
+    a_max = a.max()
+    delta = (a_max - a_min) / bins
+    for i in nb.prange(bin_edges.shape[0]):
+        bin_edges[i] = a_min + i * delta
+
+    bin_edges[-1] = a_max  # Avoid roundoff error on last point
+    return bin_edges
+
+
+@dpjit
+def compute_bin(x, bin_edges):
+    # assuming uniform bins for now
+    n = bin_edges.shape[0] - 1
+    a_min = bin_edges[0]
+    a_max = bin_edges[-1]
+
+    # special case to mirror NumPy behavior for last bin
+    if x == a_max:
+        return n - 1  # a_max always in last bin
+
+    return int(n * (x - a_min) / (a_max - a_min))
+
+
+@dpjit
+def histogram_prange(a, bins, weights):
+    hist = np.zeros((bins,), dtype=a.dtype)
+    bin_edges = get_bin_edges_prange(a, bins)
+
+    for i in nb.prange(a.shape[0]):
+        bin = compute_bin(a[i], bin_edges)
+        hist[bin] += weights[i]
+
+    return hist, bin_edges
+
+
+@dpjit
+def azimint_hist(data, radius, npt):
+    histu = np.histogram(radius, npt)[0]
+    # histw = np.histogram(radius, npt, weights=data)[0]
+    histw = histogram_prange(radius, npt, weights=data)[0]
+    return histw / histu

--- a/dpbench/benchmarks/npbench/azimint_naive/azimint_naive_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/azimint_naive/azimint_naive_numba_dpex_p.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2014 Jérôme Kieffer et al.
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Jérôme Kieffer and Giannis Ashiotis. Pyfai: a python library for
+high performance azimuthal integration on gpu, 2014. In Proceedings of the
+7th European Conference on Python in Science (EuroSciPy 2014).
+"""
+
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def azimint_naive(data, radius, npt):
+    rmax = radius.max()
+    res = np.zeros(npt, dtype=np.float64)
+    for i in nb.prange(npt):
+        r1 = rmax * i / npt
+        r2 = rmax * (i + 1) / npt
+        mask_r12 = np.logical_and((r1 <= radius), (radius < r2))
+        values_r12 = data[mask_r12]
+        res[i] = values_r12.mean()
+    return res

--- a/dpbench/benchmarks/npbench/contour_integral/contour_integral_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/contour_integral/contour_integral_numba_dpex_p.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def contour_integral(NR, NM, slab_per_bc, Ham, int_pts, Y):
+    P0 = np.zeros((NR, NM), dtype=np.complex128)
+    P1 = np.zeros((NR, NM), dtype=np.complex128)
+    # for z in int_pts:
+    for i in nb.prange(len(int_pts)):
+        z = int_pts[i]
+        Tz = np.zeros((NR, NR), dtype=np.complex128)
+        for n in nb.prange(slab_per_bc + 1):
+            zz = np.power(z, slab_per_bc / 2 - n)
+            Tz += zz * Ham[n]
+        if NR == NM:
+            X = np.linalg.inv(Tz)
+        else:
+            X = np.linalg.solve(Tz, Y)
+        if abs(z) < 1.0:
+            X = -X
+        P0 += X
+        P1 += z * X
+
+    return P0, P1

--- a/dpbench/benchmarks/npbench/deep_learning/conv2d_bias/conv2d_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/deep_learning/conv2d_bias/conv2d_numba_dpex_p.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+# Deep learning convolutional operator (stride = 1)
+@dpjit
+def conv2d(input, weights):
+    K = weights.shape[0]  # Assuming square kernel
+    N = input.shape[0]
+    H_out = input.shape[1] - K + 1
+    W_out = input.shape[2] - K + 1
+    C_in = input.shape[3]
+    C_out = weights.shape[3]
+    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+
+    # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
+    for i in nb.prange(H_out):
+        for j in nb.prange(W_out):
+            # output[:, i, j, :] = np.sum(
+            #     input[:, i:i + K, j:j + K, :, np.newaxis] *
+            #     weights[np.newaxis, :, :, :],
+            #     axis=(1, 2, 3),
+            # )
+            # Reshape supported only on contiguous arrays
+            inp = input[:, i : i + K, j : j + K, :].copy()
+            # Tuple of ints not supported in axis keyword
+            output[:, i, j, :] = np.sum(
+                np.sum(
+                    np.sum(
+                        np.reshape(inp, (N, K, K, C_in, 1))
+                        * np.reshape(weights, (1, K, K, C_in, C_out)),
+                        axis=1,
+                    ),
+                    axis=1,
+                ),
+                axis=1,
+            )
+
+    return output
+
+
+@dpjit
+def conv2d_bias(input, weights, bias):
+    return conv2d(input, weights) + bias

--- a/dpbench/benchmarks/npbench/deep_learning/lenet/lenet_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/deep_learning/lenet/lenet_numba_dpex_p.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def relu(x):
+    return np.maximum(x, 0)
+
+
+# Deep learning convolutional operator (stride = 1)
+@dpjit
+def conv2d(input, weights):
+    K = weights.shape[0]  # Assuming square kernel
+    N = input.shape[0]
+    H_out = input.shape[1] - K + 1
+    W_out = input.shape[2] - K + 1
+    C_in = input.shape[3]
+    C_out = weights.shape[3]
+    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+
+    # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
+    for i in nb.prange(H_out):
+        for j in nb.prange(W_out):
+            # output[:, i, j, :] = np.sum(
+            #     input[:, i:i + K, j:j + K, :, np.newaxis] *
+            #     weights[np.newaxis, :, :, :],
+            #     axis=(1, 2, 3),
+            # )
+            # Reshape supported only on contiguous arrays
+            inp = input[:, i : i + K, j : j + K, :].copy()
+            # Tuple of ints not supported in axis keyword
+            output[:, i, j, :] = np.sum(
+                np.sum(
+                    np.sum(
+                        np.reshape(inp, (N, K, K, C_in, 1))
+                        * np.reshape(weights, (1, K, K, C_in, C_out)),
+                        axis=1,
+                    ),
+                    axis=1,
+                ),
+                axis=1,
+            )
+
+    return output
+
+
+# 2x2 maxpool operator, as used in LeNet-5
+@dpjit
+def maxpool2d(x):
+    # output = np.empty(
+    #     [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
+    #     dtype=x.dtype)
+    output = np.empty(
+        (x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]),
+        dtype=x.dtype,
+    )
+    for i in nb.prange(x.shape[1] // 2):
+        for j in nb.prange(x.shape[2] // 2):
+            # output[:, i, j, :] = np.max(x[:, 2 * i:2 * i + 2,
+            #                               2 * j:2 * j + 2, :],
+            #                             axis=(1, 2))
+            for k in nb.prange(x.shape[0]):
+                for l in nb.prange(x.shape[3]):  # noqa: E741 math variable
+                    output[k, i, j, l] = np.max(
+                        x[k, 2 * i : 2 * i + 2, 2 * j : 2 * j + 2, l]
+                    )
+    return output
+
+
+# LeNet-5 Convolutional Neural Network (inference mode)
+@dpjit
+def lenet5(
+    input,
+    conv1,
+    conv1bias,
+    conv2,
+    conv2bias,
+    fc1w,
+    fc1b,
+    fc2w,
+    fc2b,
+    fc3w,
+    fc3b,
+    N,
+    C_before_fc1,
+):
+    x = relu(conv2d(input, conv1) + conv1bias)
+    x = maxpool2d(x)
+    x = relu(conv2d(x, conv2) + conv2bias)
+    x = maxpool2d(x)
+    x = np.reshape(x, (N, C_before_fc1))
+    x = relu(x @ fc1w + fc1b)
+    x = relu(x @ fc2w + fc2b)
+    return x @ fc3w + fc3b

--- a/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/deep_learning/mlp/mlp_numba_dpex_p.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def relu(x):
+    return np.maximum(x, 0)
+
+
+# Numerically-stable version of softmax
+@dpjit
+def softmax(x):
+    new_shape = (x.shape[0], 1)
+    # tmp_max = np.max(x, axis=-1, keepdims=True)
+    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    for i in nb.prange(x.shape[0]):
+        tmp_max[i, 0] = np.max(x[i])
+    tmp_out = np.exp(x - tmp_max)
+    # tmp_sum = np.sum(tmp_out, axis=-1, keepdims=True)
+    tmp_sum = np.reshape(np.sum(tmp_out, axis=-1), new_shape)
+    return tmp_out / tmp_sum
+
+
+# 3-layer MLP
+@dpjit
+def mlp(input, w1, b1, w2, b2, w3, b3):
+    x = relu(input @ w1 + b1)
+    x = relu(x @ w2 + b2)
+    x = softmax(x @ w3 + b3)  # Softmax call can be omitted if necessary
+    return x

--- a/dpbench/benchmarks/npbench/deep_learning/resnet/resnet_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/deep_learning/resnet/resnet_numba_dpex_p.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def relu(x):
+    return np.maximum(x, 0)
+
+
+# Deep learning convolutional operator (stride = 1)
+@dpjit
+def conv2d(input, weights):
+    K = weights.shape[0]  # Assuming square kernel
+    N = input.shape[0]
+    H_out = input.shape[1] - K + 1
+    W_out = input.shape[2] - K + 1
+    C_in = input.shape[3]
+    C_out = weights.shape[3]
+    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+
+    # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
+    for i in nb.prange(H_out):
+        for j in nb.prange(W_out):
+            # output[:, i, j, :] = np.sum(
+            #     input[:, i:i + K, j:j + K, :, np.newaxis] *
+            #     weights[np.newaxis, :, :, :],
+            #     axis=(1, 2, 3),
+            # )
+            # Reshape supported only on contiguous arrays
+            inp = input[:, i : i + K, j : j + K, :].copy()
+            # Tuple of ints not supported in axis keyword
+            output[:, i, j, :] = np.sum(
+                np.sum(
+                    np.sum(
+                        np.reshape(inp, (N, K, K, C_in, 1))
+                        * np.reshape(weights, (1, K, K, C_in, C_out)),
+                        axis=1,
+                    ),
+                    axis=1,
+                ),
+                axis=1,
+            )
+
+    return output
+
+
+# Batch normalization operator, as used in ResNet
+@dpjit
+def batchnorm2d(x, eps=1e-5):
+    # mean = np.mean(x, axis=0, keepdims=True)
+    mean = np.empty(x.shape, dtype=x.dtype)
+    mean[:] = np.sum(x, axis=0) / x.shape[0]
+    # std = np.std(x, axis=0, keepdims=True)
+    std = np.empty(x.shape, dtype=x.dtype)
+    std[:] = np.sqrt(np.sum((x - mean) ** 2, axis=0) / x.shape[0])
+    return (x - mean) / np.sqrt(std + eps)
+
+
+# Bottleneck residual block (after initial convolution, without downsampling)
+# in the ResNet-50 CNN (inference)
+@dpjit
+def resnet_basicblock(input, conv1, conv2, conv3):
+    # Pad output of first convolution for second convolution
+    padded = np.zeros(
+        (input.shape[0], input.shape[1] + 2, input.shape[2] + 2, conv1.shape[3])
+    )
+
+    padded[:, 1:-1, 1:-1, :] = conv2d(input, conv1)
+    x = batchnorm2d(padded)
+    x = relu(x)
+
+    x = conv2d(x, conv2)
+    x = batchnorm2d(x)
+    x = relu(x)
+    x = conv2d(x, conv3)
+    x = batchnorm2d(x)
+    return relu(x + input)

--- a/dpbench/benchmarks/npbench/deep_learning/softmax/softmax_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/deep_learning/softmax/softmax_numba_dpex_p.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+# Numerically-stable version of softmax
+@dpjit
+def softmax(x):
+    new_shape = (x.shape[0], x.shape[1], x.shape[2], 1)
+    # tmp_max = np.max(x, axis=-1, keepdims=True)
+    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    for i in nb.prange(x.shape[3]):
+        tmp_max[:, :, :, 0] = np.max(x[:, :, :, i])
+    tmp_out = np.exp(x - tmp_max)
+    # tmp_sum = np.sum(tmp_out, axis=-1, keepdims=True)
+    tmp_sum = np.reshape(np.sum(tmp_out, axis=-1), new_shape)
+    return tmp_out / tmp_sum

--- a/dpbench/benchmarks/npbench/go_fast/go_fast_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/go_fast/go_fast_numba_dpex_p.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2012-2020 Anaconda, Inc. and others
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://numba.readthedocs.io/en/stable/user/5minguide.html
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def go_fast(a):
+    trace = 0.0
+    for i in nb.prange(a.shape[0]):
+        trace += np.tanh(a[i, i])
+    return a + trace

--- a/dpbench/benchmarks/npbench/mandelbrot1/mandelbrot1_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/mandelbrot1/mandelbrot1_numba_dpex_p.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2017 Nicolas P. Rougier
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# more information at https://github.com/rougier/numpy-book
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def linspace(start, stop, num, dtype):
+    X = np.empty((num,), dtype=dtype)
+    dist = (stop - start) / (num - 1)
+    for i in nb.prange(num):
+        X[i] = start + i * dist
+    return X
+
+
+@dpjit
+def mandelbrot(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon=2.0):
+    # Adapted from https://www.ibm.com/developerworks/community/blogs/jfp/...
+    #              .../entry/How_To_Compute_Mandelbrodt_Set_Quickly?lang=en
+    # X = np.linspace(xmin, xmax, xn, dtype=np.float64)
+    # Y = np.linspace(ymin, ymax, yn, dtype=np.float64)
+    X = linspace(xmin, xmax, xn, dtype=np.float64)
+    Y = linspace(ymin, ymax, yn, dtype=np.float64)
+    # C = X + Y[:,None]*1j
+    C = X + np.reshape(Y, (yn, 1)) * 1j
+    N = np.zeros(C.shape, dtype=np.int64)
+    Z = np.zeros(C.shape, dtype=np.complex128)
+    for n in range(maxiter):
+        # I = np.less(abs(Z), horizon)
+        I = np.less(np.absolute(Z), horizon)  # noqa: E741 math variable
+        # N[I] = n
+        for j in nb.prange(C.shape[0]):
+            for k in nb.prange(C.shape[1]):
+                if I[j, k]:
+                    N[j, k] = n
+                    # Z[I] = Z[I]**2 + C[I]
+                    # for j in nb.prange(C.shape[0]):
+                    #    for k in nb.prange(C.shape[1]):
+                    #:        if I[j, k]:
+                    Z[j, k] = Z[j, k] ** 2 + C[j, k]
+    # N[N == maxiter-1] = 0
+    for j in nb.prange(C.shape[0]):
+        for k in nb.prange(C.shape[1]):
+            if N[j, k] == maxiter - 1:
+                N[j, k] = 0
+    return Z, N

--- a/dpbench/benchmarks/npbench/scattering_self_energies/scattering_self_energies_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/scattering_self_energies/scattering_self_energies_numba_dpex_p.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def scattering_self_energies(neigh_idx, dH, G, D, Sigma):
+    for k in nb.prange(G.shape[0]):
+        for E in nb.prange(G.shape[1]):
+            for q in nb.prange(D.shape[0]):
+                for w in nb.prange(D.shape[1]):
+                    for i in nb.prange(D.shape[-2]):
+                        for j in nb.prange(D.shape[-1]):
+                            for a in nb.prange(neigh_idx.shape[0]):
+                                for b in nb.prange(neigh_idx.shape[1]):
+                                    if E - w >= 0:
+                                        dHG = (
+                                            G[k, E - w, neigh_idx[a, b]]
+                                            @ dH[a, b, i]
+                                        )
+                                        dHD = dH[a, b, j] * D[q, w, a, b, i, j]
+                                        Sigma[k, E, a] += dHG @ dHD

--- a/dpbench/benchmarks/npbench/spmv/spmv_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/spmv/spmv_numba_dpex_p.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+
+# Sparse Matrix-Vector Multiplication (SpMV)
+from numba_dpex import dpjit
+
+
+# Matrix-Vector Multiplication with the matrix given in Compressed Sparse Row
+# (CSR) format
+@dpjit
+def spmv(A_row, A_col, A_val, x):
+    y = np.empty(A_row.size - 1, A_val.dtype)
+
+    for i in nb.prange(A_row.size - 1):
+        cols = A_col[A_row[i] : A_row[i + 1]]
+        vals = A_val[A_row[i] : A_row[i + 1]]
+        y[i] = vals @ x[cols]
+
+    return y

--- a/dpbench/benchmarks/npbench/stockham_fft/stockham_fft_numba_dpex_p.py
+++ b/dpbench/benchmarks/npbench/stockham_fft/stockham_fft_numba_dpex_p.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def mgrid(xn, yn):
+    Xi = np.empty((xn, yn), dtype=np.uint32)
+    Yi = np.empty((xn, yn), dtype=np.uint32)
+    for i in nb.prange(xn):
+        Xi[i, :] = i
+    for j in nb.prange(yn):
+        Yi[:, j] = j
+    return Xi, Yi
+
+
+@dpjit
+def stockham_fft(N, R, K, x, y):
+    # Generate DFT matrix for radix R.
+    # Define transient variable for matrix.
+    i_coord, j_coord = mgrid(R, R)
+    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
+    # Move input x to output y
+    # to avoid overwriting the input.
+    y[:] = x[:]
+
+    # ii_coord, jj_coord = np.mgrid[0:R, 0:R**K]
+    ii_coord, jj_coord = mgrid(R, R**K)
+
+    # Main Stockham loop
+    for i in range(K):
+        # Stride permutation
+        yv = np.reshape(y, (R**i, R, R ** (K - i - 1)))
+        # tmp_perm = np.transpose(yv, axes=(1, 0, 2))
+        tmp_perm = np.transpose(yv, axes=(1, 0, 2)).copy()
+        # Twiddle Factor multiplication
+        D = np.empty((R, R**i, R ** (K - i - 1)), dtype=np.complex128)
+        tmp = np.exp(
+            -2.0j
+            * np.pi
+            * ii_coord[:, : R**i]
+            * jj_coord[:, : R**i]
+            / R ** (i + 1)
+        )
+        # D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R ** (K-i-1), axis=2)
+        for k in nb.prange(R ** (K - i - 1)):
+            D[:, :, k] = tmp
+        tmp_twid = np.reshape(tmp_perm, (N,)) * np.reshape(D, (N,))
+        # Product with Butterfly
+        y[:] = np.reshape(
+            dft_mat @ np.reshape(tmp_twid, (R, R ** (K - 1))), (N,)
+        )

--- a/dpbench/benchmarks/polybench/datamining/correlation/correlation_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/datamining/correlation/correlation_numba_dpex_p.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(M, float_n, data):
+    # mean = np.mean(data, axis=0)
+    mean = np.sum(data, axis=0) / float_n
+    # stddev = np.std(data, axis=0)
+    stddev = np.sqrt(np.sum((data - mean) ** 2, axis=0) / float_n)
+    stddev[stddev <= 0.1] = 1.0
+    data -= mean
+    data /= np.sqrt(float_n) * stddev
+    corr = np.eye(M, dtype=data.dtype)
+    for i in nb.prange(M - 1):
+        corr[i + 1 : M, i] = corr[i, i + 1 : M] = (
+            data[:, i] @ data[:, i + 1 : M]
+        )
+
+    return corr

--- a/dpbench/benchmarks/polybench/datamining/covariance/covariance_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/datamining/covariance/covariance_numba_dpex_p.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(M, float_n, data):
+    # mean = np.mean(data, axis=0)
+    mean = np.sum(data, axis=0) / float_n
+    data -= mean
+    cov = np.zeros((M, M), dtype=data.dtype)
+    # for i in nb.prange(M):
+    #     for j in nb.prange(i, M):
+    #         cov[i, j] = np.sum(data[:, i] * data[:, j])
+    #         cov[i, j] /= float_n - 1.0
+    #         cov[j, i] = cov[i, j]
+    for i in nb.prange(M):
+        cov[i:M, i] = cov[i, i:M] = data[:, i] @ data[:, i:M] / (float_n - 1.0)
+
+    return cov

--- a/dpbench/benchmarks/polybench/linear-algebra/blas/symm/symm_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/linear-algebra/blas/symm/symm_numba_dpex_p.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(alpha, beta, C, A, B):
+    temp2 = np.empty((C.shape[1],), dtype=C.dtype)
+    C *= beta
+    for i in range(C.shape[0]):
+        for j in nb.prange(C.shape[1]):
+            C[:i, j] += alpha * B[i, j] * A[i, :i]
+            temp2[j] = B[:i, j] @ A[i, :i]
+        C[i, :] += alpha * B[i, :] * A[i, i] + alpha * temp2

--- a/dpbench/benchmarks/polybench/linear-algebra/blas/trmm/trmm_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/linear-algebra/blas/trmm/trmm_numba_dpex_p.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(alpha, A, B):
+    for i in range(B.shape[0]):
+        for j in nb.prange(B.shape[1]):
+            B[i, j] += np.dot(A[i + 1 :, i], B[i + 1 :, j])
+    B *= alpha

--- a/dpbench/benchmarks/polybench/linear-algebra/solvers/cholesky/cholesky_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/linear-algebra/solvers/cholesky/cholesky_numba_dpex_p.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(A):
+    A[0, 0] = np.sqrt(A[0, 0])
+    for i in range(1, A.shape[0]):
+        for j in nb.prange(i):
+            A[i, j] -= np.dot(A[i, :j], A[j, :j])
+            A[i, j] /= A[j, j]
+        A[i, i] -= np.dot(A[i, :i], A[i, :i])
+        A[i, i] = np.sqrt(A[i, i])

--- a/dpbench/benchmarks/polybench/medley/floyd_warshall/floyd_warshall_numba_dpex_p.py
+++ b/dpbench/benchmarks/polybench/medley/floyd_warshall/floyd_warshall_numba_dpex_p.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2010-2016 Ohio State University
+# SPDX-FileCopyrightText: 2021 ETH Zurich and the NPBench authors
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dpnp as np
+import numba as nb
+from numba_dpex import dpjit
+
+
+@dpjit
+def kernel(path):
+    for k in range(path.shape[0]):
+        # path[:] = np.minimum(path[:], np.add.outer(path[:, k], path[k, :]))
+        for i in nb.prange(path.shape[0]):
+            path[i, :] = np.minimum(path[i, :], path[i, k] + path[k, :])


### PR DESCRIPTION
Add `numba_dpex_p` implementation based on the `numba_npr` implementation.

```
Report for 2023-05-03 10:56:53 run
==================================
Legend
======
        postfix                            description
0  numba_dpex_p  Numba-dpex prange
1  numba_npr     Numba nopython, Parallel=True, prange
2  numpy         NumPy

Summary of current implementation
=================================
   input_size                 benchmark problem_preset      numba_dpex_p          numba_npr    numpy
0         6MB              azimint_hist              S  Failed Execution  Failed Validation  Success
1         6MB             azimint_naive              S  Failed Execution            Success  Success
2        78KB                  cholesky              S  Failed Execution            Success  Success
3       234KB          contour_integral              S  Failed Execution   Failed Execution  Success
4        96KB               conv2d_bias              S  Failed Execution            Success  Success
5         2MB               correlation              S  Failed Execution   Failed Execution  Success
6         2MB                covariance              S  Failed Execution   Failed Execution  Success
7       156KB            floyd_warshall              S  Failed Execution            Success  Success
8        30MB                   go_fast              S  Failed Execution            Success  Success
9          0B               mandelbrot1              S  Failed Execution   Failed Execution  Success
10      244MB                       mlp              S  Failed Execution            Success  Success
11       19KB  scattering_self_energies              S  Failed Execution   Failed Execution  Success
12       16MB                   softmax              S  Failed Execution            Success  Success
13      144KB                      spmv              S  Failed Execution            Success  Success
14        1MB              stockham_fft              S  Failed Execution   Failed Execution  Success
15       43KB                      symm              S  Failed Execution            Success  Success
16       73KB                      trmm              S  Failed Execution            Success  Success
Summary of current implementation
=================================
   input_size                 benchmark problem_preset numba_dpex_p numba_npr     numpy
0         6MB              azimint_hist              S          n/a    7.68ms    5.49ms
1         6MB             azimint_naive              S          n/a  153.58ms  259.22ms
2        78KB                  cholesky              S          n/a    9.18ms   10.04ms
3       234KB          contour_integral              S          n/a       n/a    9.94ms
4        96KB               conv2d_bias              S          n/a    2.14ms    6.69ms
5         2MB               correlation              S          n/a       n/a   14.91ms
6         2MB                covariance              S          n/a       n/a   11.51ms
7       156KB            floyd_warshall              S          n/a    7.76ms     7.0ms
8        30MB                   go_fast              S          n/a     2.0ms    4.84ms
9          0B               mandelbrot1              S          n/a       n/a    9.15ms
10      244MB                       mlp              S          n/a   27.09ms   13.77ms
11       19KB  scattering_self_energies              S          n/a       n/a     5.5ms
12       16MB                   softmax              S          n/a   37.92ms   22.21ms
13      144KB                      spmv              S          n/a    0.68ms    7.11ms
14        1MB              stockham_fft              S          n/a       n/a    5.16ms
15       43KB                      symm              S          n/a    1.78ms     5.4ms
16       73KB                      trmm              S          n/a    1.21ms    4.64ms
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
