### PR TITLE
Refactor benchmark results

### DIFF
--- a/dpbench/infrastructure/benchmark_results.py
+++ b/dpbench/infrastructure/benchmark_results.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from dpbench.infrastructure.datamodel import Result
+from dpbench.infrastructure.enums import ErrorCodes, ValidationStatusCodes
+
+
+@dataclass
+class BenchmarkResults:
+    """A helper class to store the results and timing from running a
+    benchmark.
+    """
+
+    repeats: int
+    impl_postfix: str
+    preset: str
+    input_size: int = 0
+
+    setup_time: float = 0.0
+    warmup_time: float = 0.0
+    teardown_time: float = 0.0
+
+    min_exec_time: float = 0.0
+    quartile25_exec_time: float = 0.0
+    median_exec_time: float = 0.0
+    quartile75_exec_time: float = 0.0
+    max_exec_time: float = 0.0
+
+    validation_state: ValidationStatusCodes = ValidationStatusCodes.NA
+    error_state: ErrorCodes = ErrorCodes.UNIMPLEMENTED
+    error_msg: str = "Not implemented"
+
+    @property
+    def exec_times(self):
+        """Returns an array of execution timings measured in nanoseconds
+
+        Returns:
+            numpy.ndarray: An array of execution times for each repetition of
+            the main execution.
+        """
+        return self._exec_times
+
+    @exec_times.setter
+    def exec_times(self, exec_times):
+        if not exec_times:
+            exec_times = [0.0]
+        quartiles = np.percentile(exec_times, [25, 50, 75])
+        self.min_exec_time = min(exec_times)
+        self.quartile25_exec_time = quartiles[0]
+        self.median_exec_time = quartiles[1]
+        self.quartile75_exec_time = quartiles[2]
+        self.max_exec_time = max(exec_times)
+
+    def Result(self, run_id: int, benchmark_name, framework_version) -> Result:
+        if self.error_state == ErrorCodes.UNIMPLEMENTED:
+            error_state_str = "Unimplemented"
+        elif self.error_state == ErrorCodes.NO_FRAMEWORK:
+            error_state_str = "Framework unavailable"
+        elif self.error_state == ErrorCodes.FAILED_EXECUTION:
+            error_state_str = "Failed Execution"
+        elif self.error_state == ErrorCodes.FAILED_VALIDATION:
+            error_state_str = "Failed Validation"
+        elif self.error_state == ErrorCodes.EXECUTION_TIMEOUT:
+            error_state_str = "Execution Timeout"
+        elif self.error_state == ErrorCodes.SUCCESS:
+            error_state_str = "Success"
+        else:
+            error_state_str = "N/A"
+
+        return Result(
+            run_id=run_id,
+            benchmark=benchmark_name,
+            implementation=self.impl_postfix,
+            # TODO: platform
+            platform="TODO",
+            framework_version=framework_version,
+            error_state=error_state_str,
+            problem_preset=self.preset,
+            input_size=self.input_size,
+            setup_time=self.setup_time,
+            warmup_time=self.warmup_time,
+            repeats=str(self.repeats),
+            min_exec_time=self.min_exec_time,
+            max_exec_time=self.max_exec_time,
+            median_exec_time=self.median_exec_time,
+            quartile25_exec_time=self.quartile25_exec_time,
+            quartile75_exec_time=self.quartile75_exec_time,
+            teardown_time=self.teardown_time,
+            validated="Success"
+            if self.validation_state == ValidationStatusCodes.SUCCESS
+            else "Fail",
+        )

--- a/dpbench/infrastructure/runner.py
+++ b/dpbench/infrastructure/runner.py
@@ -17,6 +17,7 @@ import dpbench.benchmarks as dp_bms
 import dpbench.config as cfg
 import dpbench.infrastructure as dpbi
 from dpbench.infrastructure.enums import ErrorCodes
+from dpbench.infrastructure.frameworks.framework import Framework
 
 
 def _format_ns(time_in_ns):
@@ -29,25 +30,25 @@ def _format_ns(time_in_ns):
             return f"{scaled_time}{s} ({time} ns)"
 
 
-def _print_results(result: dpbi.BenchmarkResults):
+def _print_results(result: dpbi.BenchmarkResults, framework: Framework):
     print(
         "================ implementation "
-        + result.benchmark_impl_postfix
+        + result.impl_postfix
         + " ========================\n"
         + "implementation:",
-        result.benchmark_impl_postfix,
+        result.impl_postfix,
     )
 
     if result.error_state == ErrorCodes.SUCCESS:
-        print("framework:", result.framework_name)
-        print("framework version:", result.framework_version)
+        print("framework:", framework.fname)
+        print("framework version:", framework.version())
         print("setup time:", _format_ns(result.setup_time))
         print("warmup time:", _format_ns(result.warmup_time))
         print("teardown time:", _format_ns(result.teardown_time))
         print("max execution times:", _format_ns(result.max_exec_time))
         print("min execution times:", _format_ns(result.min_exec_time))
         print("median execution times:", _format_ns(result.median_exec_time))
-        print("repeats:", result.num_repeats)
+        print("repeats:", result.repeats)
         print("preset:", result.preset)
         print("validated:", result.validation_state)
     else:
@@ -133,8 +134,8 @@ def run_benchmark(
             run_id=run_id,
         )
         if print_results:
-            for result in results:
-                _print_results(result)
+            for result, framework in results:
+                _print_results(result, framework)
 
     except Exception:
         logging.exception(


### PR DESCRIPTION
Update `BenchmarkResults` into dataclass, so it is fast and easy to transfer this object between processes. This update required to make framework run in different processes.

Some side effects improvements:
Instead of throwing exception, it just print nicely that implementation postfix was not found for the test.

```
================ Benchmark KMeans ========================

ERROR [root] No implementation exists for postfix: numba_mlir_p
================ implementation numba_mlir_p ========================
implementation: numba_mlir_p
error states: ErrorCodes.UNIMPLEMENTED
error msg: No implementation
```

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
