### PR TITLE
Move ref impl to config

### DIFF
--- a/dpbench/config/benchmark.py
+++ b/dpbench/config/benchmark.py
@@ -88,6 +88,7 @@ class Benchmark:
     array_args: List[str] = field(default_factory=list)
     output_args: List[str] = field(default_factory=list)
     implementations: List[BenchmarkImplementation] = field(default_factory=list)
+    reference_implementation_postfix: str = None
     expected_failure_implementations: List[str] = field(default_factory=list)
 
     @staticmethod
@@ -108,6 +109,9 @@ class Benchmark:
         _array_args = obj.get("array_args") or []
         _output_args = obj.get("output_args") or []
         _implementations = obj.get("implementations") or []
+        _reference_implementation_postfix = obj.get(
+            "reference_implementation_postfix"
+        )
         _expected_failure_implementations = (
             obj.get("expected_failure_implementations") or []
         )
@@ -126,5 +130,6 @@ class Benchmark:
             _array_args,
             _output_args,
             _implementations,
+            _reference_implementation_postfix,
             _expected_failure_implementations,
         )

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -363,21 +363,19 @@ class Benchmark(object):
 
         """
 
-        ref_impl = None
-
-        python_impl = [
-            impl for impl in self.impl_fnlist if "python" in impl.name
+        reference_implementations = [
+            impl
+            for impl in self.impl_fnlist
+            if self.info.reference_implementation_postfix in impl.name
         ]
-        numpy_impl = [impl for impl in self.impl_fnlist if "numpy" in impl.name]
 
-        if numpy_impl:
-            ref_impl = numpy_impl[0]
-        elif python_impl:
-            ref_impl = python_impl[0]
-        else:
+        print(self.impl_fnlist)
+        print(reference_implementations)
+
+        if len(reference_implementations) == 0:
             raise RuntimeError("No reference implementation")
 
-        return ref_impl
+        return reference_implementations[0]
 
     def _set_impl_to_framework_map(self) -> dict[str, Framework]:
         """Create a dictionary mapping each implementation function name to a


### PR DESCRIPTION
Now python and numpy Frameworks loads no matter what user set in run arguments.
Logic of determining reference implementation moved to configuration load. It is possible to set it in configuration now.
Prevents validation fail if user request just one implementation to run and it is not `python` or `numpy`

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
