### PR TITLE
Install dependencies from file

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -38,21 +38,14 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
+          mamba-version: "*"
           activate-environment: dpbench-dev
+          environment-file: dpbench-env-linux.yml
 
       - name: Conda info
         shell: bash -l {0}
-        run: conda info
-
-      - name: Install dpbench dependencies
-        shell: bash -l {0}
         run: |
-          conda install -c intel tbb dpcpp_linux-64
-          conda install numpy numba cython cmake ninja scikit-build pandas
-          conda install scipy scikit-learn pybind11 tomli
-          conda install -c pkgs/main libgcc-ng">=11.2.0" libstdcxx-ng">=11.2.0" libgomp">=11.2.0"
-          conda install -c dppy/label/dev -c intel -c main dpctl numba-dpex dpnp numba-mlir
-          pip install alembic
+          conda info
           conda list
 
       - name: Build dpbench

--- a/dpbench-env-linux.yml
+++ b/dpbench-env-linux.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: dpbench-dev
+channels:
+  - dppy/label/dev
+  - intel
+  - conda-forge
+dependencies:
+  - tbb
+  - dpcpp_linux-64
+  - numpy
+  - numba
+  - cython
+  - cmake>=3.22
+  - ninja
+  - scikit-build
+  - pandas
+  - scipy
+  - scikit-learn
+  - pybind11
+  - tomli
+  - dpctl
+  - numba-dpex
+  - dpnp
+  - numba-mlir
+  - libgcc-ng>=11.2.0
+  - libstdcxx-ng>=11.2.0
+  - libgomp>=11.2.0
+
+  - pip:
+    - alembic


### PR DESCRIPTION
* Install CI dependencies from yaml file instead of random collection of `conda install`s with random channels
* Use `mamba` on CI for faster deps resolving