### PR TITLE
Add special device "none" for numba-mlir framework

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -71,3 +71,13 @@ jobs:
         shell: bash -l {0}
         run: |
           dpbench -i ${WORKLOADS} report || exit 1
+
+      - name: Run numba-mlir host benchmarks
+        shell: bash -l {0}
+        run: |
+          dpbench -i numba_mlir_n,numba_mlir_p run -r2 --sycl-device "none" -p S || exit 1
+
+      - name: Numba-mlir host benchmarks report
+        shell: bash -l {0}
+        run: |
+          dpbench -i numba_mlir_n,numba_mlir_p report || exit 1

--- a/dpbench/infrastructure/frameworks/numba_mlir_framework.py
+++ b/dpbench/infrastructure/frameworks/numba_mlir_framework.py
@@ -12,6 +12,10 @@ import dpbench.config as cfg
 from .framework import Framework
 
 
+def _has_device(device):
+    return device and device != "none"
+
+
 class NumbaMlirFramework(Framework):
     """A class for reading and processing framework information."""
 
@@ -28,7 +32,7 @@ class NumbaMlirFramework(Framework):
         """Returns the copy-method that should be used
         for copying the benchmark arguments to device."""
 
-        if self.sycl_device:
+        if _has_device(self.sycl_device):
             import dpctl.tensor as dpt
 
             def _copy_to_func_impl(ref_array):
@@ -58,7 +62,7 @@ class NumbaMlirFramework(Framework):
         any array created by the framework possibly on
         a device memory domain."""
 
-        if self.sycl_device:
+        if _has_device(self.sycl_device):
             import dpctl.tensor as dpt
 
             return dpt.asnumpy


### PR DESCRIPTION
* This special device name allow to skip offload entirely and run benchmarks on host
* Update CI script