### PR TITLE
Removing atomics usage in kmeans implementations

### DIFF
--- a/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
+++ b/dpbench/benchmarks/kmeans/kmeans_numba_dpex_k.py
@@ -31,12 +31,14 @@ def calCentroidsSum1(arrayCsum, arrayCnumpoint):
 
 
 @dpex.kernel
-def calCentroidsSum2(arrayP, arrayPcluster, arrayCsum, arrayCnumpoint):
-    i = dpex.get_global_id(0)
-    ci = arrayPcluster[i]
-    dpex.atomic.add(arrayCsum, (ci, 0), arrayP[i, 0])
-    dpex.atomic.add(arrayCsum, (ci, 1), arrayP[i, 1])
-    dpex.atomic.add(arrayCnumpoint, ci, 1)
+def calCentroidsSum2(
+    arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points
+):
+    for i in range(num_points):
+        ci = arrayPcluster[i]
+        arrayCsum[ci, 0] += arrayP[i, 0]
+        arrayCsum[ci, 1] += arrayP[i, 1]
+        arrayCnumpoint[ci] += 1
 
 
 @dpex.kernel
@@ -73,8 +75,8 @@ def kmeans_kernel(
 
         calCentroidsSum1[num_centroids,](arrayCsum, arrayCnumpoint)
 
-        calCentroidsSum2[num_points,](
-            arrayP, arrayPcluster, arrayCsum, arrayCnumpoint
+        calCentroidsSum2[1,](
+            arrayP, arrayPcluster, arrayCsum, arrayCnumpoint, num_points
         )
 
         updateCentroids[num_centroids,](

--- a/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_kernel.hpp
+++ b/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_kernel.hpp
@@ -68,24 +68,15 @@ void kmeans_impl(sycl::queue q,
         // Compute centroid sum
         q.submit([&](sycl::handler &h) {
              h.parallel_for<class theKernel_2>(
-                 sycl::range<1>{npoints}, [=](sycl::id<1> myID) {
-                     size_t i0 = myID[0];
-                     size_t ci = arrayPclusters[i0];
-
-                     for (size_t j = 0; j < ndims; j++) {
-                         sycl::atomic_ref<
-                             FpTy, sycl::memory_order::relaxed,
-                             sycl::memory_scope::system,
-                             sycl::access::address_space::global_space>
-                             centroid_sum(arrayCsum[ci * ndims + j]);
-                         centroid_sum += arrayP[i0 * ndims + j];
+                 sycl::range<1>{1}, [=](sycl::id<1> myID) {
+                     for (size_t i0 = 0; i0 < npoints; i0++) {
+                         size_t ci = arrayPclusters[i0];
+                         for (size_t j = 0; j < ndims; j++) {
+                             arrayCsum[ci * ndims + j] +=
+                                 arrayP[i0 * ndims + j];
+                         }
+                         arrayCnumpoint[ci] += 1;
                      }
-
-                     sycl::atomic_ref<size_t, sycl::memory_order::relaxed,
-                                      sycl::memory_scope::system,
-                                      sycl::access::address_space::global_space>
-                         centroid_num_points(arrayCnumpoint[ci]);
-                     centroid_num_points += 1;
                  });
          }).wait();
 


### PR DESCRIPTION
Atomics usage in kmeans dpex and sycl implementations was causing bloated execution times relative to numba impl.
Since the entire kernel was being executed sequentially, created a kernel with single work-item and added a serial loop.

Run times with 'M' input after the change:
---------------------------------------------------
================ implementation numba_npr ========================
implementation: numba_npr
framework: numba
framework version: 0.56.4
setup time: 6.254485ms (6254485 ns)
warmup time: 1.306626777s (1306626777 ns)
teardown time: 0ns (0 ns)
max execution times: 134.4529ms (134452900 ns)
min execution times: 134.4529ms (134452900 ns)
median execution times: 134.4529ms (134452900 ns)
repeats: 1
preset: M
validated: Not Validated
================ implementation numba_dpex_p ========================
implementation: numba_dpex_p
framework: numba_dpex
framework version: 0.21.0.dev0+23.gee08e9b0
setup time: 370.209271ms (370209271 ns)
warmup time: 878.86514ms (878865140 ns)
teardown time: 0ns (0 ns)
max execution times: 142.448107ms (142448107 ns)
min execution times: 142.448107ms (142448107 ns)
median execution times: 142.448107ms (142448107 ns)
repeats: 1
preset: M
validated: Not Validated
================ implementation numba_dpex_k ========================
implementation: numba_dpex_k
framework: numba_dpex
framework version: 0.21.0.dev0+23.gee08e9b0
setup time: 4.755188ms (4755188 ns)
warmup time: 523.635898ms (523635898 ns)
teardown time: 0ns (0 ns)
max execution times: 236.541688ms (236541688 ns)
min execution times: 236.541688ms (236541688 ns)
median execution times: 236.541688ms (236541688 ns)
repeats: 1
preset: M
validated: Not Validated
================ implementation sycl ========================
implementation: sycl
framework: dpcpp
framework version: IntelLLVM 2023.1.0
setup time: 187.614693ms (187614693 ns)
warmup time: 247.621724ms (247621724 ns)
teardown time: 0ns (0 ns)
max execution times: 86.360412ms (86360412 ns)
min execution times: 86.360412ms (86360412 ns)
median execution times: 86.360412ms (86360412 ns)
repeats: 1
preset: M
validated: Not Validated


- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
