### PR TITLE
Use latest packages from conda_forge

### DIFF
--- a/environments/conda-linux-sycl.yml
+++ b/environments/conda-linux-sycl.yml
@@ -5,18 +5,18 @@
 name: dpbench-dev
 channels:
   - dppy/label/dev
-  - intel
   - conda-forge
+  - intel
   - nodefaults
 dependencies:
-  - conda-forge::pip
-  - conda-forge::tomli
-  - conda-forge::alembic>=1.11.0
-  - conda-forge::sqlalchemy>=2.0.0
-  - conda-forge::scipy
-  - conda-forge::scikit-learn
-  - conda-forge::pandas
-  - numpy
+  - pip
+  - tomli
+  - alembic
+  - sqlalchemy
+  - scipy
+  - scikit-learn
+  - pandas
+  - intel::numpy
   - numba
   - dpctl
   - dpnp
@@ -24,12 +24,12 @@ dependencies:
   - numba-mlir
   - dpcpp_linux-64
   - cython
-  - cmake>=3.22
+  - cmake
   - ninja
   - scikit-build
   # https://github.com/scikit-build/scikit-build/issues/981
   - setuptools>=42,<64
   - pybind11
-  - conda-forge::libgcc-ng
-  - conda-forge::libstdcxx-ng
-  - conda-forge::libgomp
+  - libgcc-ng
+  - libstdcxx-ng
+  - libgomp

--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -5,18 +5,18 @@
 name: dpbench-dev
 channels:
   - dppy/label/dev
-  - intel
   - conda-forge
+  - intel
   - nodefaults
 dependencies:
-  - conda-forge::pip
-  - conda-forge::tomli
-  - conda-forge::alembic>=1.11.0
-  - conda-forge::sqlalchemy>=2.0.0
-  - conda-forge::scipy
-  - conda-forge::scikit-learn
-  - conda-forge::pandas
-  - numpy
+  - pip
+  - tomli
+  - alembic
+  - sqlalchemy
+  - scipy
+  - scikit-learn
+  - pandas
+  - intel::numpy
   - numba
   - dpctl
   - dpnp


### PR DESCRIPTION
Use latest packages from conda forge by putting `conda-forge` above `intel` package. Most of the bindings for channel and version no longer required.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
