### PR TITLE
Added dtype parameter in dpnp.sum() function call for avoid copying.

### DIFF
--- a/dpbench/benchmarks/gpairs/gpairs_dpnp.py
+++ b/dpbench/benchmarks/gpairs/gpairs_dpnp.py
@@ -12,7 +12,10 @@ def _gpairs_impl(x1, y1, z1, w1, x2, y2, z2, w2, rbins):
         + np.square(z2 - z1[:, None])
     )
     return np.array(
-        [np.outer(w1, w2)[dm <= rbins[k]].sum() for k in range(len(rbins))],
+        [
+            np.outer(w1, w2)[dm <= rbins[k]].sum(dtype=np.result_type(w1, w2))
+            for k in range(len(rbins))
+        ],
         device=x1.device,
     )
 

--- a/dpbench/benchmarks/l2_norm/l2_norm_dpnp.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_dpnp.py
@@ -7,5 +7,5 @@ import dpnp as np
 
 def l2_norm(a, d):
     sq = np.square(a)
-    sum = sq.sum(axis=1)
+    sum = sq.sum(axis=1, dtype=sq.dtype)
     d[:] = np.sqrt(sum)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_dpnp.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_dpnp.py
@@ -6,8 +6,8 @@ import dpnp as np
 
 
 def pairwise_distance(X1, X2, D):
-    x1 = np.sum(np.square(X1), axis=1)
-    x2 = np.sum(np.square(X2), axis=1)
+    x1 = np.sum(np.square(X1), axis=1, dtype=X1.dtype)
+    x2 = np.sum(np.square(X2), axis=1, dtype=X2.dtype)
     np.dot(X1, X2.T, D)
     D *= -2
     x3 = x1.reshape(x1.size, 1)


### PR DESCRIPTION
Out parameter for function dpnp.sum() has double-precision floating-point dtype for all floating-point input dtypes.
Added dtype parameter in dpnp.sum() function call for avoid unnecessary copying when input parameter has single-precision floating-point dtype.

<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
