### PR TITLE
Remove expected failure for dpnp benchmarks.

### DIFF
--- a/dpbench/configs/bench_info/l2_norm.toml
+++ b/dpbench/configs/bench_info/l2_norm.toml
@@ -21,7 +21,7 @@ array_args = [
 output_args = [
     "d",
 ]
-expected_failure_implementations = ["dpnp", "numba_dpex_n"]
+expected_failure_implementations = ["numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 32768

--- a/dpbench/configs/bench_info/pairwise_distance.toml
+++ b/dpbench/configs/bench_info/pairwise_distance.toml
@@ -23,7 +23,7 @@ array_args = [
 output_args = [
     "D",
 ]
-expected_failure_implementations = ["dpnp", "numba_dpex_n"]
+expected_failure_implementations = ["numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 1024

--- a/dpbench/configs/bench_info/pca.toml
+++ b/dpbench/configs/bench_info/pca.toml
@@ -21,7 +21,7 @@ output_args = [
     "evalues",
     "evectors",
 ]
-expected_failure_implementations = ["dpnp", "numba_dpex_n"]
+expected_failure_implementations = ["numba_dpex_n"]
 
 [benchmark.parameters.S]
 npoints = 1024


### PR DESCRIPTION
Remove expected failure for dpnp benchmarks: l2_norm, pairwise_distance, and pca.

<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
