### PR TITLE
Added dtype parameter in np.cov() function call.

### DIFF
--- a/dpbench/benchmarks/pca/pca_dpnp.py
+++ b/dpbench/benchmarks/pca/pca_dpnp.py
@@ -10,7 +10,7 @@ def pca(data, dims_rescaled_data=2):
     data -= data.mean(axis=0)
 
     # calculate the covariance matrix
-    v = np.cov(data, rowvar=False)
+    v = np.cov(data, rowvar=False, dtype=data.dtype)
 
     # calculate eigenvectors & eigenvalues of the covariance matrix
     evalues, evectors = np.linalg.eigh(v)

--- a/dpbench/benchmarks/pca/pca_numpy.py
+++ b/dpbench/benchmarks/pca/pca_numpy.py
@@ -10,7 +10,7 @@ def pca(data, dims_rescaled_data=2):
     data -= data.mean(axis=0)
 
     # calculate the covariance matrix
-    v = np.cov(data, rowvar=False)
+    v = np.cov(data, rowvar=False, dtype=data.dtype)
 
     # calculate eigenvectors & eigenvalues of the covariance matrix
     evalues, evectors = np.linalg.eigh(v)


### PR DESCRIPTION
Function np.cov() returns double-precision floating-point dtype by default. 
Added dtype parameter in np.cov() function call to avoid upcast of results dtype for single-precision floating-point input.

<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
