### PR TITLE
Do not request ref_framework if validation is not needed

### DIFF
--- a/dpbench/infrastructure/benchmark_runner.py
+++ b/dpbench/infrastructure/benchmark_runner.py
@@ -318,12 +318,13 @@ class BenchmarkRunner:
 
         brc = BaseRunConfig.from_instance(rc)
 
-        brc.ref_framework: cfg.Framework = [
-            f
-            for f in cfg.GLOBAL.frameworks
-            if rc.benchmark.reference_implementation_postfix
-            in {p.postfix for p in f.postfixes}
-        ][0]
+        if rc.validate:
+            brc.ref_framework: cfg.Framework = [
+                f
+                for f in cfg.GLOBAL.frameworks
+                if rc.benchmark.reference_implementation_postfix
+                in {p.postfix for p in f.postfixes}
+            ][0]
 
         conn.send(brc)
 


### PR DESCRIPTION
To avoid crashes when no ref framework available and user passes `--no-validate`
