### PR TITLE
Disable channel priority

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -51,14 +51,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup conda
+      - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python }}
-          mamba-version: "*"
-          activate-environment: dpbench-dev
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: "build"
+          channel-priority: "disabled"
           environment-file: environments/${{ matrix.environment }}
+          run-post: false
 
       - name: Conda info
         shell: bash -el {0}
@@ -66,8 +68,9 @@ jobs:
           conda info
           conda list
 
-      - name: Configure Intel OpenCL CPU RT
-        if: matrix.os == 'windows-latest'
+
+      - name: Setup OpenCL CPU device
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
@@ -80,14 +83,14 @@ jobs:
           Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Configure Python
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           # Set python encoding to support utf-8 symblos like ms.
           echo "PYTHONIOENCODING=utf-8" >> $env:GITHUB_ENV
 
       - name: Patch IntelLLVM cmake
-        if: matrix.os == 'windows-latest' && matrix.sycl == 'sycl'
+        if: runner.os == 'Windows' && matrix.sycl == 'sycl'
         shell: pwsh
         run: |
           $env:PATCHED_CMAKE_VERSION="3.26"

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -13,7 +13,8 @@ on:
 env:
   PACKAGE_NAME: dpbench
   MODULE_NAME: dpbench
-  CHANNELS: '-c dppy/label/dev -c conda-forge -c intel -c nodefaults --override-channels'
+  # There is a separate action that removes defaults.
+  CHANNELS: 'dppy/label/dev,conda-forge,intel'
   VER_JSON_NAME: 'version.json'
   VER_SCRIPT1: "import json; f = open('version.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['dpbench'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
@@ -48,33 +49,28 @@ jobs:
           fetch-depth: 0
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
-          activate-environment: 'build'
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: "build"
+          channels: ${{ env.CHANNELS }}
+          channel-priority: "disabled"
+          run-post: false
+
+      - name: Disable defautls
+        run: conda config --remove channels defaults
 
       - name: Store conda paths as envs
         run: echo "CONDA_BLD=$CONDA_PREFIX/conda-bld/${{ runner.os == 'Linux' && 'linux' || 'win' }}-64/" | tr "\\" '/' >> $GITHUB_ENV
 
+      # boa is an extention to conda so we can use mamba resolver in conda build
       - name: Install conda-build
-        run: conda install conda-build
-
-      - name: Cache conda packages
-        uses: actions/cache@v3.2.6
-        env:
-          CACHE_NUMBER: 1  # Increase to reset cache
-        with:
-          path: ${{ env.CONDA_PKGS_DIR }}
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('**/meta.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
+        run: mamba install boa
 
       - name: Build conda package
-        run: conda build --no-test --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
+        run: conda mambabuild --no-test --python ${{ matrix.python }} conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3.1.2
@@ -104,12 +100,18 @@ jobs:
 
     steps:
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python }}
-          miniconda-version: 'latest'
-          activate-environment: 'test'
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: "build"
+          channels: ${{ env.CHANNELS }}
+          channel-priority: "disabled"
+          run-post: false
+
+      - name: Disable defautls
+        run: conda config --remove channels defaults
 
       - name: Store conda paths as envs
         shell: bash -l {0}
@@ -135,7 +137,7 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: conda install conda-build
+        run: mamba install conda-build
 
       - name: Create conda channel
         run: conda index ${{ env.CHANNEL_PATH }}
@@ -145,38 +147,8 @@ jobs:
           conda search ${{ env.PACKAGE_NAME }} -c ${{ env.CHANNEL_PATH }} --override-channels --info --json > ${{ env.VER_JSON_PATH }}
           cat ${{ env.VER_JSON_PATH }}
 
-      - name: Collect dependencies
-        shell: bash -l {0}
-        run: |
-          export PACKAGE_VERSION=$(python -c "${{ env.VER_SCRIPT1 }} ${{ env.VER_SCRIPT2 }}")
-
-          echo PACKAGE_VERSION=${PACKAGE_VERSION}
-          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-
-          conda install ${{ env.PACKAGE_NAME }}=${PACKAGE_VERSION} python=${{ matrix.python }} ${{ env.TEST_CHANNELS }} --only-deps --dry-run > lockfile
-          cat lockfile
-        env:
-          TEST_CHANNELS: '-c ${{ env.CHANNEL_PATH }} ${{ env.CHANNELS }}'
-
-      - name: Cache conda packages
-        uses: actions/cache@v3.2.6
-        env:
-          CACHE_NUMBER: 1 # Increase to reset cache
-        with:
-          path: ${{ env.CONDA_PKGS_DIR }}
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-${{hashFiles('lockfile') }}
-          restore-keys: |
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-python-${{ matrix.python }}-
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
-
-      - name: Install opencl_rt
-        run: conda install opencl_rt -c intel --override-channels
-
       - name: Install dpbench
-        run: conda install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} pytest python=${{ matrix.python }} ${{ env.TEST_CHANNELS }}
-        env:
-          TEST_CHANNELS: '-c ${{ env.CHANNEL_PATH }} ${{ env.CHANNELS }}'
+        run: mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} pytest opencl_rt python=${{ matrix.python }} -c ${{ env.CHANNEL_PATH }}
 
       - name: List installed packages
         run: conda list

--- a/environments/conda-win-sycl.yml
+++ b/environments/conda-win-sycl.yml
@@ -27,6 +27,7 @@ dependencies:
   - cmake
   - cython
   - scikit-build
+  - intel::intel-opencl-rt # need for set-intel-ocl-icd-registry.ps1
   # https://github.com/scikit-build/scikit-build/issues/981
   - setuptools>=42,<64
   - pybind11

--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -17,6 +17,7 @@ dependencies:
   - scipy
   - scikit-learn
   - pandas
+  - intel::intel-opencl-rt # need for set-intel-ocl-icd-registry.ps1
   - intel::numpy
   - numba
   - dpctl


### PR DESCRIPTION
Target CI issues in https://github.com/IntelPython/dpbench/pull/287 , which is failing due to old version of numba-dpex being installed. Removing channel priority and disabling default channel should make the trick to always install latest dependencies. Use `conda mambabuild` to speed up pipelines and disable conda package cleanup to speed up windows CI.

Some bug with `intel-opencl-rt` found: windows package differ on intel and conda-forge channel. The last one does not have registry set script, that prevents sycl to see `opencl:cpu` device. As workaround: pinned to use intel channel for it.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
