### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -11,19 +11,26 @@ on:
 
 env:
   # sycl is not included. Add it manually if you need
-  WORKLOADS: python,numpy,dpnp,numba_n,numba_np,numba_npr,numba_dpex_k,numba_dpex_n,numba_dpex_p,numba_mlir_k,numba_mlir_n,numba_mlir_p
+  WORKLOADS: python,numpy,dpnp,numba_n,numba_np,numba_npr,numba_dpex_k,numba_dpex_n,numba_dpex_p
 
 jobs:
-  build_linux:
+  build:
     name: Build and run
 
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python: ["3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
         sycl: ["sycl","no-sycl"]
         install: ["pip", "setup.py"]
+        exclude:
+          # setuptools<64 + scikit-build produce 'UNKOWN' package name for
+          # python 3.11. Could not find exact reference for that issue.
+          # latest setuptools is unable to create editable environment for pip
+          - python: "3.11"
+            install: "pip"
+            sycl: "sycl"
         include:
           - sycl: sycl
             os: ubuntu-latest
@@ -40,6 +47,10 @@ jobs:
 
     runs-on: ${{matrix.os}}
 
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -50,6 +61,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # intel:numpy for python 3.11 is not upstreamed yet
+      - name: Patch numpy dependency for Python 3.11
+        if: matrix.python == '3.11'
+        shell: bash -l {0}
+        run: |
+          find ./environments -type f | xargs sed -i 's/intel::numpy/numpy/'
+          find ./environments -type f | xargs sed -i '/numba-mlir/d'
+          find ./environments -type f | xargs sed -i 's/setuptools>=42,<64/setuptools/'
+
+      # TODO: remove once numba_mlir support python 3.11
+      - name: Patch numpy dependency for Python 3.11
+        if: matrix.python != '3.11'
+        shell: bash -l {0}
+        run: |
+          echo "WORKLOADS=$WORKLOADS,numba_mlir_k,numba_mlir_n,numba_mlir_p" >> "$GITHUB_ENV"
 
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
@@ -63,24 +90,9 @@ jobs:
           run-post: false
 
       - name: Conda info
-        shell: bash -el {0}
         run: |
           conda info
           conda list
-
-
-      - name: Setup OpenCL CPU device
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
-          &$script_path
-          echo "OCL_ICD_FILENAMES=$env:CONDA_PREFIX\Library\lib\intelocl64.dll" >> $env:GITHUB_ENV
-          echo "LIB=$env:CONDA_PREFIX\Library\lib;$env:CONDA_PREFIX\compiler\lib;$env:LIB" >> $env:GITHUB_ENV
-          echo "INCLUDE=$env:CONDA_PREFIX\include;$env:INCLUDE" >> $env:GITHUB_ENV
-          # Check the variable assisting OpenCL CPU driver to find TBB DLLs which are not located where it expects them by default
-          $cl_cfg="$env:CONDA_PREFIX\Library\lib\cl.cfg"
-          Get-Content -Tail 5 -Path $cl_cfg
 
       - name: Configure Python
         if: runner.os == 'Windows'
@@ -98,6 +110,20 @@ jobs:
           $env:FN="Windows-IntelLLVM.cmake"
           Copy-Item ".github\workflows\Windows-IntelLLVM_${env:PATCHED_CMAKE_VERSION}.cmake" "${env:PLATFORM_DIR}\${env:FN}"
 
+      # TODO: remove it once it is removed from hard dependency. Not presented
+      # in conda-forge version, but there are some blockers before we could use
+      # it.
+      - name: Remove vs env
+        if: runner.os == 'Windows' && matrix.sycl == 'sycl'
+        run: |
+          conda remove --force vs2017_win-64
+
+      - name: Configure MSBuild
+        if: runner.os == 'Windows' && matrix.sycl == 'sycl'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.35
+
       - name: Configure Sycl
         if: matrix.sycl == 'sycl'
         shell: bash -el {0}
@@ -108,31 +134,47 @@ jobs:
           echo "DPBENCH_SYCL=1" >> "$GITHUB_ENV"
           echo "WORKLOADS=$WORKLOADS,sycl" >> "$GITHUB_ENV"
 
+      - name: Configure compiler
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+
+      - name: Configure OneAPI
+        run: |
+          echo "ONEAPI_DEVICE_SELECTOR=opencl:cpu" >> "$GITHUB_ENV"
+
+      - name: Populate conda environment paths
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          echo "LIB=$env:CONDA_PREFIX\Library\lib;$env:CONDA_PREFIX\compiler\lib;$env:LIB" >> $env:GITHUB_ENV
+          echo "INCLUDE=$env:CONDA_PREFIX\include;$env:INCLUDE" >> $env:GITHUB_ENV
+
       - name: Build dpbench
         if: matrix.install == 'pip'
-        shell: bash -el {0}
-        run: |
-          pip install \
-          --no-index --no-deps --no-build-isolation -e . -v
+        run: pip install --no-index --no-deps --no-build-isolation -e . -v
 
       - name: Build dpbench
         if: matrix.install == 'setup.py'
+        run: python setup.py develop
+
+      - name: Configure dpbench
         shell: bash -el {0}
         run: |
-          python setup.py develop
+          # TODO: do we need GPU in github acions?
+          echo "NUMBA_MLIR_GPU_RUNTIME=sycl" >> "GITHUB_ENV"
+          # Turn off numba-dpex autofall back
+          echo "NUMBA_DPEX_FALLBACK_ON_CPU=0" >> "GITHUB_ENV"
+
+      - name: Setup OpenCL CPU device
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $script_path="$env:CONDA_PREFIX\Scripts\set-intel-ocl-icd-registry.ps1"
+          &$script_path
+          echo "OCL_ICD_FILENAMES=$env:CONDA_PREFIX\Library\lib\intelocl64.dll" >> $env:GITHUB_ENV
 
       - name: Run benchmarks
-        shell: bash -el {0}
-        run: |
-          export NUMBA_MLIR_GPU_RUNTIME=sycl
-          # Turn off numba-dpex autofall back
-          export NUMBA_DPEX_FALLBACK_ON_CPU=0
-          # Make sure numba-dpex is using native atomics in github CI
-          export NUMBA_DPEX_ACTIVATE_ATOMICS_FP_NATIVE=1
-
-          dpbench -i ${WORKLOADS} run -r2 --no-print-results || exit 1
+        run: dpbench -i ${{env.WORKLOADS}} run -r2 --no-print-results || exit 1
 
       - name: Generate report
-        shell: bash -el {0}
-        run: |
-          dpbench -i ${WORKLOADS} report || exit 1
+        run: dpbench -i ${{env.WORKLOADS}} report || exit 1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -14,7 +14,7 @@ env:
   PACKAGE_NAME: dpbench
   MODULE_NAME: dpbench
   # There is a separate action that removes defaults.
-  CHANNELS: 'dppy/label/dev,conda-forge,intel'
+  CHANNELS: 'dppy/label/dev,conda-forge,intel,nodefaults'
   VER_JSON_NAME: 'version.json'
   VER_SCRIPT1: "import json; f = open('version.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['dpbench'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
@@ -26,14 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -l {0}' }}
 
     continue-on-error: false
 
@@ -63,11 +63,18 @@ jobs:
         run: conda config --remove channels defaults
 
       - name: Store conda paths as envs
+        shell: bash -l {0}
         run: echo "CONDA_BLD=$CONDA_PREFIX/conda-bld/${{ runner.os == 'Linux' && 'linux' || 'win' }}-64/" | tr "\\" '/' >> $GITHUB_ENV
 
       # boa is an extention to conda so we can use mamba resolver in conda build
       - name: Install conda-build
         run: mamba install boa
+
+      - name: Configure MSBuild
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '14.35'
 
       - name: Build conda package
         run: conda mambabuild --no-test --python ${{ matrix.python }} conda-recipe
@@ -92,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-20.04, ubuntu-latest, windows-latest]
         experimental: [false]
 
@@ -168,7 +175,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22..3.27 FATAL_ERROR)
 
 project(dpbench
     LANGUAGES CXX
@@ -14,10 +14,28 @@ project(dpbench
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 
+find_package(Python 3.9 REQUIRED
+  COMPONENTS Interpreter Development.Module)
+
+if(NOT DEFINED DPCTL_LIBRARY_PATH)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "import dpctl,os; print(os.path.dirname(dpctl.__file__));"
+        OUTPUT_VARIABLE DPCTL_LIBRARY_PATH
+        RESULT_VARIABLE RET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(RET EQUAL "1")
+        message(FATAL_ERROR "Module \'dpctl\' not found.")
+    endif()
+endif()
+
+cmake_path(APPEND DPCTL_MODULE_PATH ${DPCTL_LIBRARY_PATH} resources cmake)
+list(APPEND CMAKE_MODULE_PATH ${DPCTL_MODULE_PATH})
+
 find_package(pybind11 CONFIG REQUIRED)
-find_package(IntelDPCPP REQUIRED)
-find_package(PythonExtensions REQUIRED)
-find_package(Python3 COMPONENTS NumPy Development)
+find_package(IntelSYCL REQUIRED)
+find_package(Dpctl REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -13,12 +13,12 @@ REM @TODO: remove the setting, once transition to build backend on Windows
 REM to cmake is complete.
 SET "SETUPTOOLS_USE_DISTUTILS=stdlib"
 
-SET "DPBENCH_SYCL=1"
+set "DPBENCH_SYCL=1"
+set "CMAKE_GENERATOR=Ninja"
+set "CC=icx"
+set "CXX=icx"
 
 "%PYTHON%" setup.py clean --all
-
-set "SKBUILD_ARGS=-G Ninja -- -DCMAKE_C_COMPILER:PATH=icx -DCMAKE_CXX_COMPILER:PATH=icx"
-set "SKBUILD_ARGS=%SKBUILD_ARGS% -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 
 FOR %%V IN (14.0.0 14 15.0.0 15 16.0.0 16 17.0.0 17) DO @(
   REM set DIR_HINT if directory exists
@@ -41,15 +41,17 @@ if EXIST "%PLATFORM_DIR%" (
   if errorlevel 1 exit 1
 )
 
+@REM TODO: switch to pip build. Currently results in broken binary
+@REM %PYTHON% -m pip install --no-index --no-deps --no-build-isolation . -v
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
     rem Install and assemble wheel package from the build bits
-    "%PYTHON%" setup.py install bdist_wheel %SKBUILD_ARGS%
+    "%PYTHON%" setup.py install bdist_wheel --single-version-externally-managed --record=record.txt
     if errorlevel 1 exit 1
     copy dist\dpbench*.whl %WHEELS_OUTPUT_FOLDER%
     if errorlevel 1 exit 1
 ) ELSE (
     rem Only install
-    "%PYTHON%" setup.py install %SKBUILD_ARGS%
+    "%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
     if errorlevel 1 exit 1
 )
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,6 +8,11 @@ package:
 source:
   path: ..
 
+build:
+    number: {{ GIT_DESCRIBE_NUMBER }}
+    script_env:
+        - WHEELS_OUTPUT_FOLDER
+
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -16,20 +21,12 @@ requirements:
   host:
     - python
     - setuptools
-    - cmake
-    - ninja
-    - wheel
+    - cmake==3.26* # [win]
+    - cmake # [not win]
+    - ninja # [not win]
     - scikit-build
     - cython
     - pybind11
-    # runtime requirements, cause conda tries to install after build
-    # - tomli
-    # - alembic
-    # - sqlalchemy
-    # - py-cpuinfo
-    # - scipy
-    # - scikit-learn
-    # - pandas
     - intel::numpy
     - numba
     - dpctl
@@ -40,11 +37,11 @@ requirements:
     - tomli
     - alembic
     - sqlalchemy
-    # - py-cpuinfo
+    - py-cpuinfo
     - scipy
     - scikit-learn
     - pandas
-    - numpy
+    - intel::numpy
     - numba
     - dpctl
     - dpnp
@@ -60,10 +57,6 @@ test:
     - numba-dpex
     - numba
     - numpy
-  imports:
-    - dpbench
-  commands:
-    - python -c "import dpbench"
 
 about:
   home: https://github.com/IntelPython/dpbench

--- a/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/black_scholes/black_scholes_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _black_scholes_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    black_scholes_sycl/_black_scholes_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name black_scholes_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/black_scholes_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/dbscan/dbscan_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/dbscan/dbscan_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _dbscan_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    dbscan_sycl/_dbscan_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name dbscan_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/dbscan_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/gpairs/gpairs_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/gpairs/gpairs_sycl_native_ext/CMakeLists.txt
@@ -2,15 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _gpairs_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    gpairs_sycl/_gpairs_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name gpairs_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-
-  DESTINATION ${py_module_dest}/gpairs_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _kmeans_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    kmeans_sycl/_kmeans_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name kmeans_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/kmeans_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/knn/knn_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/knn/knn_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _knn_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    knn_sycl/_knn_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name knn_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/knn_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/l2_norm/l2_norm_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/l2_norm/l2_norm_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _l2_norm_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    l2_norm_sycl/_l2_norm_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name l2_norm_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/l2_norm_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _pairwise_distance_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    pairwise_distance_sycl/_pairwise_distance_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name pairwise_distance_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/pairwise_distance_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/benchmarks/rambo/rambo_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/rambo/rambo_sycl_native_ext/CMakeLists.txt
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(py_module_name _rambo_sycl)
-pybind11_add_module(${py_module_name}
-    MODULE
-    rambo_sycl/_rambo_sycl.cpp
-)
-target_include_directories(${py_module_name} PUBLIC ${Dpctl_INCLUDE_DIRS})
+set(module_name rambo_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}
-  DESTINATION ${py_module_dest}/rambo_sycl
+  DESTINATION ${py_module_dest}/${module_name}
 )

--- a/dpbench/configs/bench_info/gpairs.toml
+++ b/dpbench/configs/bench_info/gpairs.toml
@@ -39,7 +39,6 @@ array_args = [
 output_args = [
     "results",
 ]
-expected_failure_implementations = ["numba_dpex_k"]
 
 [benchmark.parameters.S]
 nopt = 128

--- a/dpbench/configs/bench_info/kmeans.toml
+++ b/dpbench/configs/bench_info/kmeans.toml
@@ -28,6 +28,8 @@ output_args = [
     "arrayC",
     "arrayCnumpoint",
 ]
+# TODO: remove once fixed. Fails randomly
+expected_failure_implementations = ["numba_mlir_k"]
 
 [benchmark.parameters.S]
 npoints = 4096

--- a/dpbench/configs/framework_info/dpcpp.toml
+++ b/dpbench/configs/framework_info/dpcpp.toml
@@ -10,7 +10,7 @@ postfix = "dpcpp"
 class = "DpcppFramework"
 arch = "cpu"
 sycl_device = "cpu"
-dpcpp_version = "IntelLLVM 2023.1.0"
+dpcpp_version = "IntelLLVM 2023.2.0"
 
 [[framework.postfixes]]
 impl_postfix = "sycl"

--- a/environments/conda-linux-sycl.yml
+++ b/environments/conda-linux-sycl.yml
@@ -23,7 +23,9 @@ dependencies:
   - dpnp
   - numba-dpex
   - numba-mlir
-  - dpcpp_linux-64
+  # TODO: fix issues on conda-forge build
+  - intel::dpcpp_linux-64
+  - intel::dpcpp-cpp-rt
   - cython
   - cmake
   - ninja

--- a/environments/conda-win-sycl.yml
+++ b/environments/conda-win-sycl.yml
@@ -23,10 +23,16 @@ dependencies:
   - dpnp
   - numba-dpex
   - numba-mlir
-  - dpcpp_win-64
-  - cmake
+  # TODO: switch to conda-forge, but it results in broken OpenCL rt (see below)
+  # - conda-forge::dpcpp_win-64
+  - intel::dpcpp_win-64
+  # fixing cmake version here, because we need to apply patch for IntelLLVM
+  - cmake==3.26*
   - cython
   - scikit-build
+  # TODO: switch to khronos, sycl-ls works fine, but dpctl can't select device.
+  # set's OpenCL runtime (better version of intel-opencl-rt)
+  # - khronos-opencl-icd-loader
   - intel::intel-opencl-rt # need for set-intel-ocl-icd-registry.ps1
   # https://github.com/scikit-build/scikit-build/issues/981
   - setuptools>=42,<64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 # https://github.com/pypa/pip/issues/6677
 license = { text = "Apache-2.0" }
-requires-python = ">=3.9" # TODO: lower it to 3.8
+requires-python = ">=3.9"
 dependencies = [
     "tomli",
     "alembic>=1.10.0",

--- a/setup.py
+++ b/setup.py
@@ -13,21 +13,15 @@ if not os.getenv("DPBENCH_SYCL"):
 
     cmake_args = None
 else:
-    import dpctl
-    import pybind11
     from skbuild import setup
+    from skbuild.platform_specifics import windows
 
-    pybind11_cmake_dir = pybind11.get_cmake_dir()
-    dpctl_include_dir = dpctl.get_include()
-    dpctl_cmake_dir = (
-        dpctl_include_dir.removesuffix("/include") + "/resource/cmake"
-    )
-    cmake_args = [
-        "-Dpybind11_DIR=" + pybind11_cmake_dir,
-        "-DDpctl_INCLUDE_DIRS=" + dpctl_include_dir,
-        "-DDPCTL_MODULE_PATH=" + dpctl_cmake_dir,
-    ]
+    cmake_args = ["-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"]
 
+    # Monkey patch msvc compiler environment, so scikit-build does not overwrite
+    # it. Make sure to set desired environment using:
+    # > vcvars64.bat -vcvars_ver=<vcvars_ver>
+    windows._get_msvc_compiler_env = lambda v, t: windows.CachedEnv()
 
 setup(
     # https://github.com/pypa/packaging-problems/issues/606


### PR DESCRIPTION
- Use new way of compiling python library (CMake way, not scikit-build way, which calls deprecated functions).
- Use latest compatible MSVC 2022 toolkit
- Bind some packages to intel channel. Conda-forge channels packages need further investigations
- Monkey patch msvc compiler environment set by scikit-build, so we can set it up manually (scikit-build way not allows to make precise settings, so it brings wrong environment that results in broken CI)
- Enable python 3.11 support
- Use `GIT_DESCRIBE_NUMBER` in conda build script, so newer version could be uploaded
- Add `kmeans` with `numba_mlir_k` implementation to expected failures
- Remove `gpairs` with `numba_dpex_k` implementation from expected failures (it looks like issue is gone with native atomic support in numba_dpex)

PR Checks:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
