### PR TITLE
Only trigger builds on main

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -6,8 +6,6 @@ name: build and run
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 env:
   # sycl is not included. Add it manually if you need

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '[0-9]+.[0-9]+*'
   pull_request:
 
 env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
All other checks are running during PRs and blocks PR from merging unless they are green. So we actually need to trigger only package build to get it populated.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
