### PR TITLE
Implement pairwise distance on 2d grid

### DIFF
--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_dpex_k.py
@@ -8,8 +8,8 @@ import numba_dpex as dpex
 
 @dpex.kernel
 def _pairwise_distance_kernel(X1, X2, D):
-    i = dpex.get_global_id(0)
-    j = dpex.get_global_id(1)
+    i = dpex.get_global_id(1)
+    j = dpex.get_global_id(0)
 
     X1_cols = X1.shape[1]
 
@@ -21,4 +21,4 @@ def _pairwise_distance_kernel(X1, X2, D):
 
 
 def pairwise_distance(X1, X2, D):
-    _pairwise_distance_kernel[dpex.Range(X1.shape[0], X2.shape[0])](X1, X2, D)
+    _pairwise_distance_kernel[dpex.Range(X2.shape[0], X1.shape[0])](X1, X2, D)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_mlir_k.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_numba_mlir_k.py
@@ -8,8 +8,8 @@ import numpy as np
 
 @nb.kernel(gpu_fp64_truncate="auto")
 def _pairwise_distance_kernel(X1, X2, D):
-    i = nb.get_global_id(0)
-    j = nb.get_global_id(1)
+    i = nb.get_global_id(1)
+    j = nb.get_global_id(0)
 
     X1_cols = X1.shape[1]
 
@@ -22,5 +22,5 @@ def _pairwise_distance_kernel(X1, X2, D):
 
 def pairwise_distance(X1, X2, D):
     _pairwise_distance_kernel[
-        (X1.shape[0], X2.shape[0]), nb.DEFAULT_LOCAL_SIZE
+        (X2.shape[0], X1.shape[0]), nb.DEFAULT_LOCAL_SIZE
     ](X1, X2, D)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/CMakeLists.txt
@@ -7,6 +7,7 @@ set(py_module_name _${module_name})
 python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
 add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
 target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
+target_compile_options(${py_module_name} PRIVATE -fno-sycl-id-queries-fit-in-int)
 
 file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS ${py_module_name}

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_sycl_native_ext/pairwise_distance_sycl/_pairwise_distance_kernel.hpp
@@ -6,34 +6,28 @@
 
 using namespace sycl;
 
-#ifdef __DO_FLOAT__
-#define SQRT(x) sqrtf(x)
-#else
-#define SQRT(x) sqrt(x)
-#endif
+template <typename T> class PairwiseDistanceKernel;
 
 template <typename FpTy>
 void pairwise_distance_impl(queue Queue,
-                            size_t npoints,
+                            size_t x1_npoints,
+                            size_t x2_npoints,
                             size_t ndims,
                             const FpTy *p1,
                             const FpTy *p2,
                             FpTy *distance_op)
 {
     Queue.submit([&](handler &h) {
-        h.parallel_for<class PairwiseDistanceKernel>(
-            range<1>{npoints}, [=](id<1> myID) {
-                size_t i = myID[0];
-                for (size_t j = 0; j < npoints; j++) {
-                    FpTy d = 0.;
-                    for (size_t k = 0; k < ndims; k++) {
-                        auto tmp = p1[i * ndims + k] - p2[j * ndims + k];
-                        d += tmp * tmp;
-                    }
-                    if (d != 0.0) {
-                        distance_op[i * npoints + j] = sqrt(d);
-                    }
+        h.parallel_for<PairwiseDistanceKernel<FpTy>>(
+            range<2>{x1_npoints, x2_npoints}, [=](id<2> myID) {
+                auto i = myID[0];
+                auto j = myID[1];
+                FpTy d = 0.;
+                for (size_t k = 0; k < ndims; k++) {
+                    auto tmp = p1[i * ndims + k] - p2[j * ndims + k];
+                    d += tmp * tmp;
                 }
+                distance_op[i * x2_npoints + j] = sycl::sqrt(d);
             });
     });
 


### PR DESCRIPTION
Numbers before fix (size=8192, igpu, float32)

| sycl 1d | numba-dpex 2d wrong indexes | numba-mlir 2d wrong indexes |
|-|-|-|
| 300ms | 1s | 1s |

After fix:
| sycl 2d | numba-dpex 2d | numba-mlir 2d |
|-|-|-|
| 17ms | 23ms | 17ms |

Fixes #290 