### PR TITLE
rodinia/gaussian sycl and ndpx implementation

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -176,5 +176,8 @@ jobs:
       - name: Run benchmarks
         run: dpbench -i ${{env.WORKLOADS}} run -r2 --no-print-results || exit 1
 
+      - name: Run rodinia benchmarks
+        run: dpbench -i ${{env.WORKLOADS}} --last-run run -r2 --no-print-results --rodinia --no-dpbench|| exit 1
+
       - name: Generate report
         run: dpbench -i ${{env.WORKLOADS}} report || exit 1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -195,6 +195,10 @@ jobs:
         run: |
           dpbench -i numpy -b azimint_hist run --npbench
 
+      - name: Run rodinia benchmark
+        run: |
+          dpbench run --rodinia --no-dpbench --no-validate -r 1
+
   upload_anaconda:
     name: Upload dppy/label/dev ['${{ matrix.os }}', python='${{ matrix.python }}']
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     hooks:
     -   id: pydocstyle
         # TODO: add packages one by one to enforce pydocstyle eventually
-        files: (^dpbench/config/|^scripts/|^dpbench/console/|^dpbench/infrastructure/benchmark_runner.py|^dpbench/infrastructure/benchmark_validation.py)
+        files: (^dpbench/config/|^scripts/|^dpbench/console/|^dpbench/infrastructure/benchmark_runner.py|^dpbench/infrastructure/benchmark_validation.py|^dpbench/benchmarks/rodinia)
         args: ["--convention=google"]
         # D417 does not work properly:
         # https://github.com/PyCQA/pydocstyle/issues/459

--- a/dpbench/benchmarks/CMakeLists.txt
+++ b/dpbench/benchmarks/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(kmeans)
 add_subdirectory(knn)
 add_subdirectory(gpairs)
 add_subdirectory(dbscan)
+add_subdirectory(rodinia)
 
 # generate dpcpp version into config
 set(FILE ${CMAKE_SOURCE_DIR}/dpbench/configs/framework_info/dpcpp.toml)

--- a/dpbench/benchmarks/rodinia/CMakeLists.txt
+++ b/dpbench/benchmarks/rodinia/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/dpbench/benchmarks/rodinia/CMakeLists.txt
+++ b/dpbench/benchmarks/rodinia/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(gaussian)

--- a/dpbench/benchmarks/rodinia/gaussian/CMakeLists.txt
+++ b/dpbench/benchmarks/rodinia/gaussian/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(gaussian_sycl_native_ext)

--- a/dpbench/benchmarks/rodinia/gaussian/__init__.py
+++ b/dpbench/benchmarks/rodinia/gaussian/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gaussian elimination implementation."""
+
+"""This is sycl and numba-dpex implementation for gaussian elimination
+Input
+---------
+size<int_64> : Forms an input matrix of dimensions (size x size)
+Output
+--------
+result<array<float>> : Result of the given set of linear equations using
+                        gaussian elimination.
+Method:
+The gaussian transformations are applied to the input matrix to form the
+diagonal matrix in forward elimination, and then the equations are solved
+to find the result in back substitution.
+"""

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_initialize.py
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_initialize.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Initialization function for matrices for gaussian elimination."""
+
+
+def initialize(size, Lambda, types_dict=None):
+    """Initialize the matrices based on size and type.
+
+    Args:
+        size: size for matrices(sizexsize).
+        Lambda: lambda value.
+        types_dict: data type of operand.
+
+    Returns: a: actual matrix.
+             b: base matrix (column matrix).
+             m: multiplier matrix.
+             result: result of operation.
+    """
+    import math
+
+    import numpy as np
+
+    dtype = types_dict["float"]
+
+    coe = np.empty((2 * size - 1), dtype=dtype)
+    a = np.empty((size * size), dtype=dtype)
+
+    for i in range(size):
+        coe_i = 10 * math.exp(Lambda * i)
+        j = size - 1 + i
+        coe[j] = coe_i
+        j = size - 1 - i
+        coe[j] = coe_i
+
+    for i in range(size):
+        for j in range(size):
+            a[i * size + j] = coe[size - 1 - i + j]
+
+    return (
+        a,
+        np.ones(size, dtype=dtype),
+        np.zeros((size * size), dtype=dtype),
+        np.zeros(size, dtype=dtype),
+    )

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_numba_dpex_k.py
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_numba_dpex_k.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Numba-dpex implementation for gaussian elimination."""
+
+import dpctl
+import numba_dpex
+
+
+@numba_dpex.kernel()
+def gaussian_kernel_1(m, a, size, t):
+    """Find the multiplier matrix.
+
+    Args:
+        m: multiplier matrix.
+        a: input matrix.
+        size: sizew of matrix.
+        t: current iteration.
+    """
+    if (
+        numba_dpex.get_local_id(2)
+        + numba_dpex.get_group_id(2) * numba_dpex.get_local_size(2)
+        >= size - 1 - t
+    ):
+        return
+
+    m[
+        size
+        * (
+            numba_dpex.get_local_size(2) * numba_dpex.get_group_id(2)
+            + numba_dpex.get_local_id(2)
+            + t
+            + 1
+        )
+        + t
+    ] = (
+        a[
+            size
+            * (
+                numba_dpex.get_local_size(2) * numba_dpex.get_group_id(2)
+                + numba_dpex.get_local_id(2)
+                + t
+                + 1
+            )
+            + t
+        ]
+        / a[size * t + t]
+    )
+
+
+@numba_dpex.kernel()
+def gaussian_kernel_2(m, a, b, size, t):
+    """Perform Gaussian elimination using gaussian operations for a iteration.
+
+    Args:
+        m: multiplier matrix.
+        a: input matrix.
+        b: column matrix.
+        size: size of matrices.
+        t: current iteration.
+    """
+    if (
+        numba_dpex.get_local_id(2)
+        + numba_dpex.get_group_id(2) * numba_dpex.get_local_size(2)
+        >= size - 1 - t
+    ):
+        return
+
+    if (
+        numba_dpex.get_local_id(1)
+        + numba_dpex.get_group_id(1) * numba_dpex.get_local_size(1)
+        >= size - t
+    ):
+        return
+
+    xidx = numba_dpex.get_group_id(2) * numba_dpex.get_local_size(
+        2
+    ) + numba_dpex.get_local_id(2)
+    yidx = numba_dpex.get_group_id(1) * numba_dpex.get_local_size(
+        1
+    ) + numba_dpex.get_local_id(1)
+
+    a[size * (xidx + 1 + t) + (yidx + t)] -= (
+        m[size * (xidx + 1 + t) + t] * a[size * t + (yidx + t)]
+    )
+    if yidx == 0:
+        b[xidx + 1 + t] -= m[size * (xidx + 1 + t) + (yidx + t)] * b[t]
+
+
+def gaussian(a, b, m, size, block_sizeXY, result):
+    """Perform Gaussian elimination using gaussian operations.
+
+    Args:
+        a: input matrix.
+        b: column matrix.
+        m: multiplier matrix.
+        size: size of matrices.
+        block_sizeXY: grid size.
+        result: result matrix.
+    """
+    device = dpctl.SyclDevice()
+    block_size = device.max_work_group_size
+    grid_size = int((size / block_size) + 0 if not (size % block_size) else 1)
+
+    blocksize2d = block_sizeXY
+    gridsize2d = int(
+        (size / blocksize2d) + (0 if not (size % blocksize2d) else 1)
+    )
+
+    global_range = numba_dpex.Range(1, 1, grid_size * block_size)
+    local_range = numba_dpex.Range(1, 1, block_size)
+
+    dim_blockXY = numba_dpex.Range(1, blocksize2d, blocksize2d)
+    dim_gridXY = numba_dpex.Range(
+        1, gridsize2d * blocksize2d, gridsize2d * blocksize2d
+    )
+
+    for t in range(size - 1):
+        gaussian_kernel_1[numba_dpex.NdRange(global_range, local_range)](
+            m, a, size, t
+        )
+
+        gaussian_kernel_2[numba_dpex.NdRange(dim_gridXY, dim_blockXY)](
+            m, a, b, size, t
+        )
+
+    for i in range(size):
+        result[size - i - 1] = b[size - i - 1]
+        for j in range(i):
+            result[size - i - 1] -= (
+                a[size * (size - i - 1) + (size - j - 1)] * result[size - j - 1]
+            )
+        result[size - i - 1] = (
+            result[size - i - 1] / a[size * (size - i - 1) + (size - i - 1)]
+        )

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_python.py
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_python.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gaussian elimination python serial implementation."""
+
+
+def gaussian(a, b, m, size, block_sizeXY, result):
+    """Python serial implementation for gaussian elimination.
+
+    Args:
+         a: actual matrix.
+         b: base matrix (column matrix).
+         m: multiplier matrix.
+         size: size for matrices(sizexsize).
+         block_sizeXY: block size for parallel 2d-kernel.
+         result: result of operation.
+    """
+    # Forward Elimination
+    for t in range(size - 1):
+        for i in range(t + 1, size):
+            m = a[i * size + t] / a[t * size + t]
+            for j in range(t, size):
+                a[i * size + j] = a[i * size + j] - m * a[t * size + j]
+            b[i] = b[i] - m * b[t]
+
+    # Back Substitution
+    for i in range(size):
+        result[size - i - 1] = b[size - i - 1]
+        for j in range(i):
+            result[size - i - 1] -= (
+                a[size * (size - i - 1) + (size - j - 1)] * result[size - j - 1]
+            )
+        result[size - i - 1] = (
+            result[size - i - 1] / a[size * (size - i - 1) + (size - i - 1)]
+        )

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/CMakeLists.txt
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(module_name gaussian_sycl)
+set(py_module_name _${module_name})
+python_add_library(${py_module_name} MODULE ${module_name}/${py_module_name}.cpp)
+add_sycl_to_target(TARGET ${py_module_name} SOURCES ${module_name}/${py_module_name}.cpp)
+target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
+
+file(RELATIVE_PATH py_module_dest ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+install(TARGETS ${py_module_name}
+  DESTINATION ${py_module_dest}/${module_name}
+)

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/__init__.py
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Sycl implementation for gaussian elimination."""
+
+from .gaussian_sycl._gaussian_sycl import gaussian as gaussian_sycl
+
+__all__ = ["gaussian_sycl"]

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/gaussian_sycl/_gaussian_kernel.hpp
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/gaussian_sycl/_gaussian_kernel.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <CL/sycl.hpp>
+
+using namespace sycl;
+
+template <typename FpTy>
+void gaussian_kernel_1(FpTy *m_device,
+                       const FpTy *a_device,
+                       int size,
+                       int t,
+                       sycl::nd_item<3> item_ct1)
+{
+    if (item_ct1.get_local_id(2) +
+            item_ct1.get_group(2) * item_ct1.get_local_range().get(2) >=
+        size - 1 - t)
+        return;
+    m_device[size * (item_ct1.get_local_range().get(2) * item_ct1.get_group(2) +
+                     item_ct1.get_local_id(2) + t + 1) +
+             t] = a_device[size * (item_ct1.get_local_range().get(2) *
+                                       item_ct1.get_group(2) +
+                                   item_ct1.get_local_id(2) + t + 1) +
+                           t] /
+                  a_device[size * t + t];
+}
+
+template <typename FpTy>
+void gaussian_kernel_2(FpTy *m_device,
+                       FpTy *a_device,
+                       FpTy *b_device,
+                       int size,
+                       int j1,
+                       int t,
+                       sycl::nd_item<3> item_ct1)
+{
+    if (item_ct1.get_local_id(2) +
+            item_ct1.get_group(2) * item_ct1.get_local_range().get(2) >=
+        size - 1 - t)
+        return;
+    if (item_ct1.get_local_id(1) +
+            item_ct1.get_group(1) * item_ct1.get_local_range().get(1) >=
+        size - t)
+        return;
+
+    int xidx = item_ct1.get_group(2) * item_ct1.get_local_range().get(2) +
+               item_ct1.get_local_id(2);
+    int yidx = item_ct1.get_group(1) * item_ct1.get_local_range().get(1) +
+               item_ct1.get_local_id(1);
+
+    a_device[size * (xidx + 1 + t) + (yidx + t)] -=
+        m_device[size * (xidx + 1 + t) + t] * a_device[size * t + (yidx + t)];
+    if (yidx == 0) {
+        b_device[xidx + 1 + t] -=
+            m_device[size * (xidx + 1 + t) + (yidx + t)] * b_device[t];
+    }
+}

--- a/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/gaussian_sycl/_gaussian_sycl.cpp
+++ b/dpbench/benchmarks/rodinia/gaussian/gaussian_sycl_native_ext/gaussian_sycl/_gaussian_sycl.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "_gaussian_kernel.hpp"
+#include <CL/sycl.hpp>
+#include <dpctl4pybind11.hpp>
+
+template <typename... Args> bool ensure_compatibility(const Args &...args)
+{
+    std::vector<dpctl::tensor::usm_ndarray> arrays = {args...};
+
+    auto arr = arrays.at(0);
+    auto q = arr.get_queue();
+    auto type_flag = arr.get_typenum();
+    auto arr_size = arr.get_size();
+
+    for (auto &arr : arrays) {
+        if (!(arr.get_flags() & (USM_ARRAY_C_CONTIGUOUS))) {
+            std::cerr << "All arrays need to be C contiguous.\n";
+            return false;
+        }
+        if (arr.get_typenum() != type_flag) {
+            std::cerr << "All arrays should be of same elemental type.\n";
+            return false;
+        }
+        if (arr.get_ndim() > 1) {
+            std::cerr << "All arrays expected to be single-dimensional.\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+void gaussian_sync(dpctl::tensor::usm_ndarray a,
+                   dpctl::tensor::usm_ndarray b,
+                   dpctl::tensor::usm_ndarray m,
+                   int size,
+                   int block_sizeXY,
+                   dpctl::tensor::usm_ndarray result)
+{
+    if (!ensure_compatibility(a, m, b, result))
+        throw std::runtime_error("Input arrays are not acceptable.");
+
+    int t;
+
+    sycl::queue q_ct1;
+
+    int block_size, grid_size;
+    block_size = q_ct1.get_device()
+                     .get_info<cl::sycl::info::device::max_work_group_size>();
+    grid_size = (size / block_size) + (!(size % block_size) ? 0 : 1);
+
+    sycl::range<3> dimBlock(1, 1, block_size);
+    sycl::range<3> dimGrid(1, 1, grid_size);
+
+    int blocksize2d, gridsize2d;
+    blocksize2d = block_sizeXY;
+    gridsize2d = (size / blocksize2d) + (!(size % blocksize2d ? 0 : 1));
+
+    sycl::range<3> dimBlockXY(1, blocksize2d, blocksize2d);
+    sycl::range<3> dimGridXY(1, gridsize2d, gridsize2d);
+
+    auto a_value = a.get_data<double>();
+    auto b_value = b.get_data<double>();
+    auto m_value = m.get_data<double>();
+
+    for (t = 0; t < (size - 1); t++) {
+        /*
+        DPCT1049:7: The workgroup size passed to the SYCL kernel may
+        exceed the limit. To get the device limit, query
+        info::device::max_work_group_size. Adjust the workgroup size if
+        needed.
+        */
+        q_ct1.submit([&](sycl::handler &cgh) {
+            auto size_ct2 = size;
+            cgh.parallel_for(sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
+                             [=](sycl::nd_item<3> item_ct1) {
+                                 gaussian_kernel_1(m_value, a_value, size_ct2,
+                                                   t, item_ct1);
+                             });
+        });
+        q_ct1.wait_and_throw();
+        /*
+        DPCT1049:8: The workgroup size passed to the SYCL kernel may
+        exceed the limit. To get the device limit, query
+        info::device::max_work_group_size. Adjust the workgroup size if
+        needed.
+        */
+        q_ct1.submit([&](sycl::handler &cgh) {
+            auto size_ct3 = size;
+            auto size_t_ct4 = size - t;
+
+            cgh.parallel_for(
+                sycl::nd_range<3>(dimGridXY * dimBlockXY, dimBlockXY),
+                [=](sycl::nd_item<3> item_ct1) {
+                    gaussian_kernel_2(m_value, a_value, b_value, size_ct3,
+                                      size_t_ct4, t, item_ct1);
+                });
+        });
+        q_ct1.wait_and_throw();
+    }
+    // Copying the final answer
+    auto result_value = result.get_data<double>();
+
+    for (int i = 0; i < size; i++) {
+
+        result_value[size - i - 1] = b_value[size - i - 1];
+
+        for (int j = 0; j < i; j++) {
+            result_value[size - i - 1] -=
+                *(a_value + size * (size - i - 1) + (size - j - 1)) *
+                result_value[size - j - 1];
+        }
+
+        result_value[size - i - 1] =
+            result_value[size - i - 1] /
+            *(a_value + size * (size - i - 1) + (size - i - 1));
+    }
+}
+
+PYBIND11_MODULE(_gaussian_sycl, m)
+{
+    // Import the dpctl extensions
+    import_dpctl();
+
+    m.def("gaussian", &gaussian_sync,
+          "DPC++ implementation of the gaussian elimination", py::arg("a"),
+          py::arg("b"), py::arg("m"), py::arg("size"), py::arg("block_sizeXY"),
+          py::arg("result"));
+}

--- a/dpbench/config/reader.py
+++ b/dpbench/config/reader.py
@@ -28,6 +28,7 @@ def read_configs(  # noqa: C901: TODO: move modules into config
     no_dpbench: bool = False,
     with_npbench: bool = False,
     with_polybench: bool = False,
+    with_rodinia: bool = False,
     load_implementations: bool = True,
 ) -> Config:
     """Read all configuration files and populate those settings into Config.
@@ -82,6 +83,18 @@ def read_configs(  # noqa: C901: TODO: move modules into config
                 benchmark_configs_recursive=True,
                 benchmarks_module="dpbench.benchmarks.polybench",
                 path=os.path.join(dirname, "../benchmarks/polybench"),
+            )
+        )
+
+    if with_rodinia:
+        modules.append(
+            Module(
+                benchmark_configs_path=os.path.join(
+                    dirname, "../configs/bench_info/rodinia"
+                ),
+                benchmark_configs_recursive=True,
+                benchmarks_module="dpbench.benchmarks.rodinia",
+                path=os.path.join(dirname, "../benchmarks/rodinia"),
             )
         )
 

--- a/dpbench/configs/bench_info/rodinia/gaussian.toml
+++ b/dpbench/configs/bench_info/rodinia/gaussian.toml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[benchmark]
+name = "Gaussian Elimination"
+short_name = "gaussian"
+relative_path = "gaussian"
+module_name = "gaussian"
+func_name = "gaussian"
+kind = "microbenchmark"
+domain = "Matrix manipulation"
+input_args = [
+    "a",
+    "b",
+    "m",
+    "size",
+    "block_sizeXY",
+    "result"
+]
+array_args = [
+    "a",
+    "b",
+    "m",
+    "result"
+]
+output_args = [
+    "result",
+]
+
+[benchmark.parameters.S]
+size = 10
+Lambda = -0.01
+block_sizeXY = 4
+
+[benchmark.parameters.M16Gb]
+size = 4096
+Lambda = -0.01
+block_sizeXY = 4
+
+[benchmark.parameters.M]
+size = 4096
+Lambda = -0.01
+block_sizeXY = 4
+
+[benchmark.parameters.L]
+size = 8192
+Lambda = -0.01
+block_sizeXY = 4
+
+[benchmark.init]
+func_name = "initialize"
+types_dict_name="types_dict"
+precision="double"
+input_args = [
+    "size",
+    "Lambda",
+    "types_dict",
+]
+output_args = [
+    "a",
+    "b",
+    "m",
+    "result"
+]

--- a/dpbench/configs/bench_info/rodinia/sample.toml
+++ b/dpbench/configs/bench_info/rodinia/sample.toml
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/dpbench/console/_namespace.py
+++ b/dpbench/console/_namespace.py
@@ -19,6 +19,7 @@ class Namespace(argparse.Namespace):
     dpbench: bool
     npbench: bool
     polybench: bool
+    rodinia: bool
     print_results: bool
     validate: bool
     run_id: Union[int, None]

--- a/dpbench/console/config.py
+++ b/dpbench/console/config.py
@@ -43,6 +43,7 @@ def execute_config(args: Namespace):
         implementations=args.implementations,
         with_npbench=True,
         with_polybench=True,
+        with_rodinia=True,
     )
 
     color_output = args.color

--- a/dpbench/console/run.py
+++ b/dpbench/console/run.py
@@ -59,6 +59,12 @@ def add_run_arguments(parser: argparse.ArgumentParser):
         help="Set if run polybench benchmarks.",
     )
     parser.add_argument(
+        "--rodinia",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Set if run rodinia benchmarks.",
+    )
+    parser.add_argument(
         "-r",
         "--repeat",
         type=int,
@@ -135,6 +141,7 @@ def execute_run(args: Namespace, conn: sqlalchemy.Engine):
         no_dpbench=not args.dpbench,
         with_npbench=args.npbench,
         with_polybench=args.polybench,
+        with_rodinia=args.rodinia,
     )
 
     if args.all_implementations:

--- a/dpbench/infrastructure/datamodel.py
+++ b/dpbench/infrastructure/datamodel.py
@@ -190,5 +190,11 @@ def store_postfix(conn: Engine, postfix: Postfix):
     :return:
     """
     with Session(conn) as session:
-        session.add(postfix)
-        session.commit()
+        existing_postfix = (
+            session.query(Postfix)
+            .filter_by(run_id=postfix.run_id, postfix=postfix.postfix)
+            .first()
+        )
+        if existing_postfix is None:
+            session.add(postfix)
+            session.commit()

--- a/dpbench/infrastructure/reporter.py
+++ b/dpbench/infrastructure/reporter.py
@@ -199,21 +199,24 @@ def generate_performance_report(
         .where(dm.Result.run_id == run_id)
     )
 
-    df = pd.read_sql_query(
-        sql=sql,
-        con=conn.connect(),
+    df = (
+        pd.read_sql_query(sql=sql, con=conn.connect())
+        .astype({impl: "string" for impl in implementations})
+        .fillna("n/a")
     )
 
     for index, row in df.iterrows():
         for impl in implementations:
             time = row[impl]
-            if time:
-                NANOSECONDS_IN_MILISECONDS: Final[float] = 1000 * 1000.0
-                time /= NANOSECONDS_IN_MILISECONDS
 
-                time = str(round(time, 2)) + "ms"
-            else:
-                time = "n/a"
+            if time == "n/a":
+                pass
+
+            NANOSECONDS_IN_MILISECONDS: Final[float] = 1000 * 1000.0
+            time = float(time)
+            time /= NANOSECONDS_IN_MILISECONDS
+
+            time = str(round(time, 2)) + "ms"
 
             df.at[index, impl] = time
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             "bench_info/polybench/linear-algebra/blas/*.toml",
             "bench_info/polybench/medley/*.toml",
             "bench_info/npbench/*.toml",
+            "bench_info/rodinia/*.toml",
             "framework_info/*.toml",
         ],
     },


### PR DESCRIPTION
Added the sycl and numba-dpex implementation for gaussian elimination benchmark for rodinia.
Runtime for 100x100 matrix with fp64 on cpu:
sycl:
max execution times: 12.190916ms (12190916 ns)
min execution times: 6.433963ms (6433963 ns)
median execution times: 7.595746ms (7595746 ns)
repeats: 10
numba_dpex_k:
max execution times: 3.994273296s (3994273296 ns)
min execution times: 2.814416425s (2814416425 ns)
median execution times: 3.585554875s (3585554875 ns)
repeats: 10