### PR TITLE
Cupy implementations of dpbench workloads

### DIFF
--- a/dpbench/benchmarks/black_scholes/black_scholes_cupy.py
+++ b/dpbench/benchmarks/black_scholes/black_scholes_cupy.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+from scipy.special import erf
+
+
+def black_scholes(nopt, price, strike, t, rate, volatility, call, put):
+    mr = -rate
+    sig_sig_two = volatility * volatility * 2
+
+    P = price
+    S = strike
+    T = t
+
+    a = np.log(P / S)
+    b = T * mr
+
+    z = T * sig_sig_two
+    c = 0.25 * z
+    y = np.true_divide(1.0, np.sqrt(z))
+
+    w1 = (a - b + c) * y
+    w2 = (a - b - c) * y
+
+    d1 = 0.5 + 0.5 * erf(w1)
+    d2 = 0.5 + 0.5 * erf(w2)
+
+    Se = np.exp(b) * S
+
+    call[:] = P * d1 - Se * d2
+    put[:] = call - P + Se

--- a/dpbench/benchmarks/gpairs/gpairs_cupy.py
+++ b/dpbench/benchmarks/gpairs/gpairs_cupy.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+
+
+def _gpairs_impl(x1, y1, z1, w1, x2, y2, z2, w2, rbins):
+    dm = (
+        np.square(x2 - x1[:, None])
+        + np.square(y2 - y1[:, None])
+        + np.square(z2 - z1[:, None])
+    )
+    return np.array(
+        [np.outer(w1, w2)[dm <= rbins[k]].sum() for k in range(len(rbins))]
+    )
+
+
+def gpairs(nopt, nbins, x1, y1, z1, w1, x2, y2, z2, w2, rbins, results):
+    results[:] = _gpairs_impl(x1, y1, z1, w1, x2, y2, z2, w2, rbins)

--- a/dpbench/benchmarks/l2_norm/l2_norm_cupy.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_cupy.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+
+
+def l2_norm(a, d):
+    sq = np.square(a)
+    sum = sq.sum(axis=1)
+    d[:] = np.sqrt(sum)

--- a/dpbench/benchmarks/pairwise_distance/pairwise_distance_cupy.py
+++ b/dpbench/benchmarks/pairwise_distance/pairwise_distance_cupy.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+
+
+def pairwise_distance(X1, X2, D):
+    x1 = np.sum(np.square(X1), axis=1)
+    x2 = np.sum(np.square(X2), axis=1)
+    np.dot(X1, X2.T, D)
+    D *= -2
+    x3 = x1.reshape(x1.size, 1)
+    np.add(D, x3, D)
+    np.add(D, x2, D)
+    np.sqrt(D, D)

--- a/dpbench/benchmarks/pca/pca_cupy.py
+++ b/dpbench/benchmarks/pca/pca_cupy.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+
+
+def pca(data, dims_rescaled_data=2):
+    # mean center the data
+    data -= data.mean(axis=0)
+
+    # calculate the covariance matrix
+    v = np.cov(data, rowvar=False, dtype=data.dtype)
+
+    # calculate eigenvectors & eigenvalues of the covariance matrix
+    evalues, evectors = np.linalg.eigh(v)
+
+    # sort eigenvalues and eigenvectors in decreasing order
+    idx = np.argsort(evalues)[::-1]
+    evectors = evectors[:, idx]
+    evalues = evalues[idx]
+
+    # select the first n eigenvectors (n is desired dimension
+    # of rescaled data array, or dims_rescaled_data)
+    evectors = evectors[:, :dims_rescaled_data]
+
+    # carry out the transformation on the data using eigenvectors
+    tdata = np.dot(evectors.T, data.T).T
+
+    # return the transformed data, eigenvalues, and eigenvectors
+    return tdata, evalues, evectors

--- a/dpbench/benchmarks/rambo/rambo_cupy.py
+++ b/dpbench/benchmarks/rambo/rambo_cupy.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as np
+
+
+def rambo(nevts, nout, C1, F1, Q1, output):
+    C = 2.0 * C1 - 1.0
+    S = np.sqrt(1 - np.square(C))
+    F = 2.0 * np.pi * F1
+    Q = -np.log(Q1)
+
+    output[:, :, 0] = Q
+    output[:, :, 1] = Q * S * np.sin(F)
+    output[:, :, 2] = Q * S * np.cos(F)
+    output[:, :, 3] = Q * C

--- a/dpbench/configs/framework_info/cupy.toml
+++ b/dpbench/configs/framework_info/cupy.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[framework]
+simple_name = "cupy"
+full_name = "cupy"
+prefix = "cp"
+postfix = "cupy"
+class = "CupyFramework"
+arch = "gpu"
+
+[[framework.postfixes]]
+impl_postfix = "cupy"
+description = "cupy"

--- a/dpbench/infrastructure/__init__.py
+++ b/dpbench/infrastructure/__init__.py
@@ -14,6 +14,7 @@ from .datamodel import (
     store_results,
 )
 from .frameworks import (
+    CupyFramework,
     DpcppFramework,
     DpnpFramework,
     Framework,
@@ -39,6 +40,7 @@ __all__ = [
     "NumbaDpexFramework",
     "NumbaMlirFramework",
     "DpnpFramework",
+    "CupyFramework",
     "DpcppFramework",
     "create_connection",
     "create_results_table",

--- a/dpbench/infrastructure/frameworks/__init__.py
+++ b/dpbench/infrastructure/frameworks/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .cupy_framework import CupyFramework
 from .dpcpp_framework import DpcppFramework
 from .dpnp_framework import DpnpFramework
 from .fabric import build_framework, build_framework_map
@@ -15,6 +16,7 @@ __all__ = [
     "NumbaFramework",
     "NumbaDpexFramework",
     "DpnpFramework",
+    "CupyFramework",
     "DpcppFramework",
     "NumbaMlirFramework",
     "build_framework",

--- a/dpbench/infrastructure/frameworks/cupy_framework.py
+++ b/dpbench/infrastructure/frameworks/cupy_framework.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable
+
+import dpbench.config as cfg
+
+from .framework import Framework
+
+
+class CupyFramework(Framework):
+    """A class for reading and processing framework information."""
+
+    def __init__(self, fname: str = None, config: cfg.Framework = None):
+        """Reads framework information.
+        :param fname: The framework name.
+        """
+
+        super().__init__(fname, config)
+
+    def copy_to_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying the benchmark arguments."""
+
+        def _copy_to_func_impl(ref_array):
+            import cupy
+
+            return cupy.asarray(ref_array)
+
+        return _copy_to_func_impl
+
+    def copy_from_func(self) -> Callable:
+        """Returns the copy-method that should be used
+        for copying the benchmark arguments."""
+        import cupy
+
+        return cupy.asnumpy

--- a/dpbench/infrastructure/frameworks/fabric.py
+++ b/dpbench/infrastructure/frameworks/fabric.py
@@ -6,6 +6,7 @@ import logging
 
 import dpbench.config as cfg
 
+from .cupy_framework import CupyFramework
 from .dpcpp_framework import DpcppFramework
 from .dpnp_framework import DpnpFramework
 from .framework import Framework
@@ -42,6 +43,7 @@ def build_framework(framework_config: cfg.Framework) -> Framework:
         Framework,
         DpcppFramework,
         DpnpFramework,
+        CupyFramework,
         NumbaFramework,
         NumbaDpexFramework,
         NumbaMlirFramework,


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

This PR adds cupy implementations of six workloads - blackscholes, gpairs, rambo, pca, l2_norm and pairwise_distance. It also contains the necessary changes to the infra to run these workloads. This PR does not contain changes to the CI to run these workloads regularly. For evidence of successful execution, see below report.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?

Tested on orsatdevnuc01 development machine. Below is the test report.

***************************************************
Report for 2023-11-02 00:05:57 run
==================================
Legend
======
  postfix description                               device
0   cupy        cupy   12th Gen Intel(R) Core(TM) i9-12900
1   dpnp        dpnp   12th Gen Intel(R) Core(TM) i9-12900
2   numpy       NumPy  12th Gen Intel(R) Core(TM) i9-12900

Summary of current implementation
=================================
  input_size          benchmark problem_preset     cupy     dpnp    numpy
0       20MB      black_scholes              S  Success  Success  Success
1        8KB             gpairs              S  Success  Success  Success
2        1MB            l2_norm              S  Success  Success  Success
3        8MB  pairwise_distance              S  Success  Success  Success
4        1MB                pca              S  Success  Success  Success
5        7MB              rambo              S  Success  Success  Success

Summary of current implementation
=================================
  input_size          benchmark problem_preset     cupy     dpnp    numpy
0       20MB      black_scholes              S   0.16ms  11.87ms  24.01ms
1        8KB             gpairs              S   1.66ms  16.81ms   0.67ms
2        1MB            l2_norm              S   0.08ms   3.75ms   0.37ms
3        8MB  pairwise_distance              S   0.14ms   2.29ms   3.28ms
4        1MB                pca              S  11.75ms  10.93ms   2.81ms
5        7MB              rambo              S   0.49ms   4.53ms   1.27ms
***************************************************

- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
