### PR TITLE
Pin github compatible msvc toolset version

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -110,11 +110,18 @@ jobs:
         run: |
           conda remove --force vs2017_win-64
 
+      # Github pre-installed versions:
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      # Intel's compatible versions:
+      # https://www.intel.com/content/www/us/en/developer/articles/reference-implementation/intel-compilers-compatibility-with-microsoft-visual-studio-and-xcode.html
+      # TODO: do we want to enforce installing version that we want?
+      #   Is it as easy as `choco install msvc==14.35`?
       - name: Configure MSBuild
         if: runner.os == 'Windows' && matrix.sycl == 'sycl'
+        # TODO: uses: microsoft/setup-msbuild ?
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          toolset: 14.35
+          toolset: 14.2
 
       - name: Configure Sycl
         if: matrix.sycl == 'sycl'
@@ -127,6 +134,7 @@ jobs:
           echo "WORKLOADS=$WORKLOADS,sycl" >> "$GITHUB_ENV"
 
       - name: Configure compiler
+        shell: bash -el {0}
         run: |
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ else:
     # Monkey patch msvc compiler environment, so scikit-build does not overwrite
     # it. Make sure to set desired environment using:
     # > vcvars64.bat -vcvars_ver=<vcvars_ver>
+    # TODO: monkey patch abstract.CMakePlatform.compile_test_cmakelist or
+    #  abstract.CMakePlatform.get_best_generator instead to chose right
+    #  complier. It will produce more stable output. We may avoid setting up
+    #  MSVC environment manually this way.
     windows._get_msvc_compiler_env = lambda v, t: windows.CachedEnv()
 
 setup(


### PR DESCRIPTION
Use MSVC 2019. Github removed 14.35 toolset from the public runner, latest compatible 2022 MSVC toolchain

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
