### PR TITLE
Report n/a instead of 0ms

### DIFF
--- a/dpbench/infrastructure/reporter.py
+++ b/dpbench/infrastructure/reporter.py
@@ -199,18 +199,21 @@ def generate_performance_report(
         .where(dm.Result.run_id == run_id)
     )
 
+    NA = "n/a"
+
     df = (
         pd.read_sql_query(sql=sql, con=conn.connect())
         .astype({impl: "string" for impl in implementations})
-        .fillna("n/a")
+        .replace("0.0", NA)
+        .fillna(NA)
     )
 
     for index, row in df.iterrows():
         for impl in implementations:
             time = row[impl]
 
-            if time == "n/a":
-                pass
+            if time == NA:
+                continue
 
             NANOSECONDS_IN_MILISECONDS: Final[float] = 1000 * 1000.0
             time = float(time)


### PR DESCRIPTION
There was a bug than resulted in reporting "0.0ms" instead of "n/a".

- [x] Have you provided a meaningful PR description?
- [ ] n/a Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
