### PR TITLE
feat: allow basic CSV output for report summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,15 @@ SPDX-License-Identifier: Apache-2.0
     --skip-expected-failures, --no-skip-expected-failures
                             Either to save execution into database. (default: True)
     ```
+
+    ```
+    usage: dpbench report [--comparisons [COMPARISON_PAIRS]] [--csv]
+
+    Subcommand to generate a summary report from the local DB
+
+    options:
+    -c, --comparisons [COMPARISON_PAIRS]
+                            Comma separated list of implementation pairs to be compared
+    --csv
+                            Sets the general summary report to output in CSV format (default: False)
+    ```

--- a/dpbench/console/report.py
+++ b/dpbench/console/report.py
@@ -28,6 +28,13 @@ def add_report_arguments(parser: argparse.ArgumentParser):
         + " compared.",
     )
 
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        default=False,
+        help="Sets the summary reports to output in CSV format",
+    )
+
 
 def execute_report(args: Namespace, conn: sqlalchemy.Engine):
     """Execute report sub command.
@@ -63,4 +70,5 @@ def execute_report(args: Namespace, conn: sqlalchemy.Engine):
         conn=conn,
         run_id=args.run_id,
         comparison_pairs=comparison_pairs,
+        csv=args.csv,
     )


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

This PR adds a basic `--csv` flag to the `dpbench report` command that can be used to change the behavior of `generate_summary()` to output the dataframe with CSV.

I need a feature like this as our benchmarking automation and regression detection rely on CSV output, and this will make it a bit easier for me to parse the data (: 

Here is an example of it:
```
dpbench report --csv
WARNING:root:using the latest run_id 1
Report for 2023-12-05 13:23:30 run
==================================
Legend
======
  postfix description                                          device
0  numpy       NumPy   11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
1  python      Python  11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz

Summary of current implementation
=================================
input_size,benchmark,problem_preset,numpy,python
20MB,black_scholes,S,Success,Success
80KB,dbscan,S,Unimplemented,Success
8KB,gpairs,S,Success,Unimplemented
96KB,kmeans,S,Unimplemented,Success
296KB,knn,S,Unimplemented,Success
1MB,l2_norm,S,Success,Unimplemented
8MB,pairwise_distance,S,Success,Unimplemented
1MB,pca,S,Success,Unimplemented
7MB,rambo,S,Success,Success

Summary of current implementation
=================================
input_size,benchmark,problem_preset,numpy,python
20MB,black_scholes,S,31.29ms,637.19ms
80KB,dbscan,S,n/a,7.78ms
8KB,gpairs,S,0.72ms,n/a
96KB,kmeans,S,n/a,247.97ms
296KB,knn,S,n/a,3833.47ms
1MB,l2_norm,S,0.3ms,n/a
8MB,pairwise_distance,S,3.29ms,n/a
1MB,pca,S,2.87ms,n/a
7MB,rambo,S,5.57ms,517.2ms

WARNING:root:these benchmarks does not fail anymore: {('kmeans', 'numba_mlir_k'), ('pca', 'numba_dpex_n'), ('knn', 'numba_dpex_p'), ('l2_norm', 'numba_dpex_n'), ('knn', 'sycl'), ('pairwise_distance', 'numba_dpex_n')}
```

Let me know if I need to add anything else to this PR or if I missed something, or if I need to change something stylistically 
