### PR TITLE
Add possibility to add custom validation function for workload

### DIFF
--- a/dpbench/benchmarks/pca/pca_validate.py
+++ b/dpbench/benchmarks/pca/pca_validate.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+from dpbench.infrastructure.benchmark_validation import (
+    validate as default_validate,
+)
+
+
+def validate(expected: dict[str, any], actual: dict[str, any], rel_error=1e-05):
+    # TODO implement actual validation suitable for pca workload
+    return default_validate(expected, actual, rel_error)

--- a/dpbench/config/benchmark.py
+++ b/dpbench/config/benchmark.py
@@ -80,6 +80,8 @@ class Benchmark:
     module_name: str = ""
     package_path: str = ""
     func_name: str = ""
+    validate_package_path: str = ""
+    validate_func_name: str = ""
     kind: str = ""
     domain: str = ""
     parameters: Presets = field(default_factory=Presets)
@@ -100,6 +102,8 @@ class Benchmark:
         _module_name = str(obj.get("module_name") or "")
         _package_path = str(obj.get("package_path") or "")
         _func_name = str(obj.get("func_name") or "")
+        _validate_package_path = str(obj.get("validate_package_path") or "")
+        _validate_func_name = str(obj.get("validate_func_name") or "validate")
         _kind = str(obj.get("kind") or "")
         _domain = str(obj.get("domain") or "")
         _parameters = Presets(obj.get("parameters"))
@@ -122,6 +126,8 @@ class Benchmark:
             _module_name,
             _package_path,
             _func_name,
+            _validate_package_path,
+            _validate_func_name,
             _kind,
             _domain,
             _parameters,

--- a/dpbench/configs/framework_info/dpcpp.toml
+++ b/dpbench/configs/framework_info/dpcpp.toml
@@ -10,7 +10,7 @@ postfix = "dpcpp"
 class = "DpcppFramework"
 arch = "cpu"
 sycl_device = "cpu"
-dpcpp_version = "IntelLLVM 2023.2.0"
+dpcpp_version = "IntelLLVM 2024.0.0"
 
 [[framework.postfixes]]
 impl_postfix = "sycl"

--- a/dpbench/infrastructure/benchmark.py
+++ b/dpbench/infrastructure/benchmark.py
@@ -52,6 +52,12 @@ class Benchmark(object):
     def init_fn_name(self):
         return self.info.init.func_name if self.info.init else None
 
+    def get_validation_func(self):
+        mod = importlib.import_module(self.info.validate_package_path)
+        validate_function = getattr(mod, self.info.validate_func_name)
+
+        return validate_function
+
     def get_implementation(self, implementation_postfix: str):
         implementation = None
 

--- a/dpbench/infrastructure/benchmark_validation.py
+++ b/dpbench/infrastructure/benchmark_validation.py
@@ -11,10 +11,12 @@ from typing import Union
 import numpy as np
 
 
-def validate_results(
-    expected: dict[str, any], actual: dict[str, any], rel_error=1e-05
-) -> bool:
-    """Checks if expected equals actual with certain precision.
+def validate(
+    expected: dict[str, any],
+    actual: dict[str, any],
+    rel_error=1e-05,
+):
+    """Default validation function.
 
     Args:
         expected: expected values.
@@ -23,25 +25,20 @@ def validate_results(
 
     Returns: true, if provided data is equal.
     """
-    if not expected:
-        return False
-
-    try:
-        for key in expected.keys():
-            valid = validate_two_lists_of_array(
-                expected[key], actual[key], rel_error=rel_error
+    valid = True
+    for key in expected.keys():
+        valid = valid and validate_two_lists_of_array(
+            expected[key], actual[key], rel_error=rel_error
+        )
+        if not valid:
+            logging.error(
+                (
+                    "Output did not match for {0}. "
+                    + "Expected: {1} Actual: {2}"
+                ).format(key, expected[key], actual[key])
             )
-            if not valid:
-                logging.error(
-                    (
-                        "Output did not match for {0}. "
-                        + "Expected: {1} Actual: {2}"
-                    ).format(key, expected[key], actual[key])
-                )
-        return valid
-    except Exception as e:
-        logging.error(f"Exception during validation {e.args}")
-        return False
+
+    return valid
 
 
 def validate_two_lists_of_array(
@@ -93,6 +90,11 @@ def relative_error(
 
     Returns: relative error.
     """
-    if np.linalg.norm(ref) == 0.0:
-        return 0.0
-    return np.linalg.norm(ref - val) / np.linalg.norm(ref)
+    ref_norm = np.linalg.norm(ref)
+    if ref_norm:
+        val_norm = np.linalg.norm(val)
+        if val_norm == 0:
+            return 0.0
+        ref_norm = val_norm
+
+    return np.linalg.norm(ref - val) / ref_norm


### PR DESCRIPTION
Adds possibility to add custom validator for workload.
dpbench search for `[workload name]_validate.py` and for `validate` function. If not found uses `default_validate`.

Fix `relative_error` for case of reference data filled filled with zeros.
Fix `valid` flag not to reset for each output.