### PR TITLE
Pin dpcpp to 2024.0.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ compiler('dpcpp') }} >=2023.1  # [not osx]
+    - {{ compiler('dpcpp') }} ==2024.0.0  # [not osx]
     - sysroot_linux-64 >=2.28  # [linux]
   host:
     - python

--- a/environments/conda-linux-sycl.yml
+++ b/environments/conda-linux-sycl.yml
@@ -25,8 +25,8 @@ dependencies:
   - numba-dpex
   - numba-mlir
   # TODO: fix issues on conda-forge build
-  - intel::dpcpp_linux-64
-  - intel::dpcpp-cpp-rt
+  - intel::dpcpp_linux-64==2024.0.0
+  - intel::dpcpp-cpp-rt==2024.0.0
   - cython
   - cmake
   - ninja

--- a/environments/conda-win-sycl.yml
+++ b/environments/conda-win-sycl.yml
@@ -26,7 +26,7 @@ dependencies:
   - numba-mlir
   # TODO: switch to conda-forge, but it results in broken OpenCL rt (see below)
   # - conda-forge::dpcpp_win-64
-  - intel::dpcpp_win-64
+  - intel::dpcpp_win-64==2024.0.0
   # fixing cmake version here, because we need to apply patch for IntelLLVM
   - cmake==3.26*
   - cython


### PR DESCRIPTION
Pin dpcpp to 2024.0.0 because conda packages with higher version missing critical binaries for sycl program compilations

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
