### PR TITLE
Fix failure in l2_norm kernel

### DIFF
--- a/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
+++ b/dpbench/benchmarks/l2_norm/l2_norm_numba_dpex_k.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import numba_dpex as dpex
-import numpy as np
 
 
 @dpex.kernel
@@ -13,7 +14,7 @@ def l2_norm_kernel(a, d):
     d[i] = 0.0
     for k in range(a_rows):
         d[i] += a[i, k] * a[i, k]
-    d[i] = np.sqrt(d[i])
+    d[i] = math.sqrt(d[i])
 
 
 def l2_norm(a, d):


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

`l2_norm` workload used `numpy.sqrt` inside numba_dpex.kernel. Changed it to using `math.sqrt` since numba_dpex currently supports only the use of explicit scalar operations inside kernel. 

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
