### PR TITLE
Fix failure in knn kernel version

### DIFF
--- a/dpbench/benchmarks/knn/knn_numba_dpex_k.py
+++ b/dpbench/benchmarks/knn/knn_numba_dpex_k.py
@@ -62,9 +62,9 @@ def _knn_kernel(  # noqa: C901: TODO: can we simplify logic?
             distance += diff * diff
         dist = sqrt(distance)
 
-        if dist < queue_neighbors[k - 1][0]:
-            queue_neighbors[k - 1][0] = dist
-            queue_neighbors[k - 1][1] = train_labels[j]
+        if dist < queue_neighbors[k - 1, 0]:
+            queue_neighbors[k - 1, 0] = dist
+            queue_neighbors[k - 1, 1] = train_labels[j]
             new_distance = queue_neighbors[k - 1, 0]
             new_neighbor_label = queue_neighbors[k - 1, 1]
             index = k - 1


### PR DESCRIPTION
- [ ] Have you provided a meaningful PR description?

knn kernel implementation was failing due to a incorrect usage of array index access. The fix now uses comma-separated index access which is expected by numba-dpex

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
