### PR TITLE
Reducing input size of preset L for pairwise distance workload

### DIFF
--- a/dpbench/configs/bench_info/pairwise_distance.toml
+++ b/dpbench/configs/bench_info/pairwise_distance.toml
@@ -41,7 +41,7 @@ dims = 3
 seed = 7777777
 
 [benchmark.parameters.L]
-npoints = 65536
+npoints = 44032
 dims = 3
 seed = 7777777
 


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

After changes to run pairwise distance on 2D grid in PR #306, numba-dpex implementations on preset L fails because the range is greater than the limits set by sycl. This PR reduces the size of L preset so that numba-dpex implementation can run successfully.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
