### PR TITLE
Log warmup overhead time

### DIFF
--- a/dpbench/infrastructure/benchmark_results.py
+++ b/dpbench/infrastructure/benchmark_results.py
@@ -132,6 +132,15 @@ class BenchmarkResults:
                 "median execution times:",
                 self._format_ns(self.median_exec_time),
             )
+            warmup_ovhd_time = int(self.warmup_time) - int(
+                self.median_exec_time
+            )
+            print(
+                "warmup overhead time (warmup time - median execution time):",
+                self._format_ns(warmup_ovhd_time)
+                if warmup_ovhd_time > 0
+                else "N/A",
+            )
             print("repeats:", self.repeats)
             print("preset:", self.preset)
             print("validated:", self.validation_state)


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Adds an entry to the output log called `warmup overhead time` which is the difference of the `median execution time` and `warm up time`. This ovehead time points to the time spent in jit-compilation (as in the case of numba-dpex) or framework load time (as in the case of dpnp, numpy). Sample output below.

Fixes #336 .

----------------
================ implementation numba_dpex_k ========================
implementation: numba_dpex_k
framework: numba_dpex
framework version: 0.22.0.dev2+3.g59d523892
input size: 20971520
setup time: 372.803065ms (372803065 ns)
warmup time: 821.023662ms (821023662 ns)
teardown time: 4.727934ms (4727934 ns)
max execution times: 2.488874ms (2488874 ns)
min execution times: 2.062158ms (2062158 ns)
median execution times: 2.091041ms (2091041 ns)
**warmup overhead time (warmup time - median execution time): 818.932621ms (818932621 ns)**
repeats: 10
preset: S
validated: Success


- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
