### PR TITLE
Fix for validation failure caused in norm calculation

### DIFF
--- a/dpbench/infrastructure/benchmark_validation.py
+++ b/dpbench/infrastructure/benchmark_validation.py
@@ -91,7 +91,7 @@ def relative_error(
     Returns: relative error.
     """
     ref_norm = np.linalg.norm(ref)
-    if ref_norm:
+    if ref_norm == 0:
         val_norm = np.linalg.norm(val)
         if val_norm == 0:
             return 0.0


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

For some workloads which were failing during execution and returning an array of zeros, validation was incorrectly reporting a success (Eg., pairwise distance with L preset). This change to the relative error calcuation fixes the incorrect validation.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
