### PR TITLE
Tuning gpairs implementation params

### DIFF
--- a/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
+++ b/dpbench/benchmarks/gpairs/gpairs_numba_dpex_k.py
@@ -37,11 +37,11 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
     lws0 = nd_item.get_local_range(0)
     lws1 = nd_item.get_local_range(1)
 
-    n_wi = 20
+    n_wi = 32
 
-    dsq_mat = dpex.private.array(shape=(20 * 20), dtype=dtype)
-    w0_vec = dpex.private.array(shape=(20), dtype=dtype)
-    w1_vec = dpex.private.array(shape=(20), dtype=dtype)
+    dsq_mat = dpex.private.array(shape=(32 * 32), dtype=dtype)
+    w0_vec = dpex.private.array(shape=(32), dtype=dtype)
+    w1_vec = dpex.private.array(shape=(32), dtype=dtype)
 
     offset0 = gr0 * n_wi * lws0 + lid0
     offset1 = gr1 * n_wi * lws1 + lid1
@@ -81,7 +81,7 @@ def count_weighted_pairs_3d_intel_no_slm_ker(
 
     # update slm_hist. Use work-item private buffer of 16 tfloat elements
     for k in range(0, slm_hist_size, private_hist_size):
-        private_hist = dpex.private.array(shape=(16), dtype=dtype)
+        private_hist = dpex.private.array(shape=(32), dtype=dtype)
         for p in range(private_hist_size):
             private_hist[p] = 0.0
 
@@ -133,8 +133,8 @@ def gpairs(
     rbins,
     results,
 ):
-    n_wi = 20
-    private_hist_size = 16
+    n_wi = 32
+    private_hist_size = 32
     lws0 = 16
     lws1 = 16
 

--- a/dpbench/benchmarks/gpairs/gpairs_sycl_native_ext/gpairs_sycl/_gpairs_kernel.hpp
+++ b/dpbench/benchmarks/gpairs/gpairs_sycl_native_ext/gpairs_sycl/_gpairs_kernel.hpp
@@ -25,7 +25,7 @@ sycl::event gpairs_impl(sycl::queue q,
                         FpTy *hist)
 {
 
-    const unsigned int n_wi = 20, private_hist_size = 16, lws0 = 16, lws1 = 16;
+    const unsigned int n_wi = 32, private_hist_size = 32, lws0 = 16, lws1 = 16;
     const size_t m0 = static_cast<size_t>(n_wi) * static_cast<size_t>(lws0);
     const size_t m1 = static_cast<size_t>(n_wi) * static_cast<size_t>(lws1);
     const size_t n_groups0 = ceiling_quotient(n, m0);


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

The gpairs implementation parameters like work group size and private memory size was initially tuned for integrated graphics devices. This PR updates the parameters determined from running experiments on Intel Datacenter Max GPUs.

CURRENT:
-----------
================ Benchmark GPairs (gpairs) ========================

WARNING:root:numba_dpex needs at least numba 0.58.0 but no more than 0.59.0, using numba=0.59.0 may cause unexpected behavior
================ implementation numba_dpex_k ========================
implementation: numba_dpex_k
framework: numba_dpex
framework version: 0.22.0.dev2+3.g59d523892
input size: 33554752
setup time: 485.043436ms (485043436 ns)
warmup time: 376.657913892s (376657913892 ns)
teardown time: 0ns (0 ns)
max execution times: 366.524516362s (366524516362 ns)
min execution times: 366.524516362s (366524516362 ns)
**median execution times: 366.524516362s (366524516362 ns)**
repeats: 1
preset: L
validated: Not Validated
================ implementation sycl ========================
implementation: sycl
framework: dpcpp
framework version: IntelLLVM 2024.0.0
input size: 33554752
setup time: 132.39452ms (132394520 ns)
warmup time: 240.888781093s (240888781093 ns)
teardown time: 0ns (0 ns)
max execution times: 243.165765882s (243165765882 ns)
min execution times: 243.165765882s (243165765882 ns)
**median execution times: 243.165765882s (243165765882 ns)**
repeats: 1
preset: L
validated: Not Validated

AFTER THIS CHANGE:
-----------------------
================ Benchmark GPairs (gpairs) ========================

WARNING:root:numba_dpex needs at least numba 0.58.0 but no more than 0.59.0, using numba=0.59.0 may cause unexpected behavior
================ implementation numba_dpex_k ========================
implementation: numba_dpex_k
framework: numba_dpex
framework version: 0.22.0.dev2+3.g59d523892
input size: 33554752
setup time: 364.385996ms (364385996 ns)
warmup time: 221.568546643s (221568546643 ns)
teardown time: 0ns (0 ns)
max execution times: 220.188768653s (220188768653 ns)
min execution times: 220.188768653s (220188768653 ns)
**median execution times: 220.188768653s (220188768653 ns)**
repeats: 1
preset: L
validated: Not Validated
================ implementation sycl ========================
implementation: sycl
framework: dpcpp
framework version: IntelLLVM 2024.0.0
input size: 33554752
setup time: 130.867229ms (130867229 ns)
warmup time: 217.880147619s (217880147619 ns)
teardown time: 0ns (0 ns)
max execution times: 218.045546452s (218045546452 ns)
min execution times: 218.045546452s (218045546452 ns)
**median execution times: 218.045546452s (218045546452 ns)**
repeats: 1
preset: L
validated: Not Validated

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
