### PR TITLE
Use python -m conda_index instead of conda index

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -156,10 +156,10 @@ jobs:
 
       # Needed to be able to run conda index
       - name: Install conda-build
-        run: mamba install conda-build
+        run: mamba install conda-build conda-index
 
       - name: Create conda channel
-        run: conda index ${{ env.CHANNEL_PATH }}
+        python -m conda_index ${{ env.CHANNEL_PATH }}
 
       - name: Test conda channel
         run: |


### PR DESCRIPTION
Github action conda package workflows are crashing with the new conda-build 24.1.2. conda index method got deprecated as part of conda-build package. Instead the proper way is to use dedicated package https://github.com/conda/conda-index .

Same issue, as in numba-dpex: https://github.com/IntelPython/numba-dpex/pull/1345

Checklist:

- [x] Have you provided a meaningful PR description?
- n/a Have you added a test, reproducer or referred to an issue with a reproducer?
- n/a Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
