### PR TITLE
Removing usage from numba_dpex.experimental

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # sycl is not included. Add it manually if you need
-  WORKLOADS: python,numpy,dpnp,numba_n,numba_np,numba_npr,numba_dpex_k,numba_dpex_n,numba_dpex_p,numba_mlir_k,numba_mlir_n,numba_mlir_p
+  WORKLOADS: python,numpy,dpnp,numba_n,numba_np,numba_npr,numba_dpex_k,numba_dpex_n,numba_dpex_p
   PYTHONIOENCODING: 'utf-8'
 
 jobs:
@@ -68,7 +68,6 @@ jobs:
         shell: bash -l {0}
         run: |
           find ./environments -type f | xargs sed -i 's/intel::numpy/numpy/'
-          find ./environments -type f | xargs sed -i '/numba-mlir/d'
           find ./environments -type f | xargs sed -i 's/setuptools>=42,<64/setuptools/'
 
       - name: Setup miniconda
@@ -168,8 +167,9 @@ jobs:
       - name: Run benchmarks
         run: dpbench -i ${{env.WORKLOADS}} run -r2 --no-print-results --precision=${{matrix.precision}} || exit 1
 
-      - name: Run rodinia benchmarks
-        run: dpbench -i ${{env.WORKLOADS}} --last-run run -r2 --no-print-results --rodinia --no-dpbench --precision=${{matrix.precision}} || exit 1
+      # TODO: Re-enable rodinia benchmarks in CI once workloads have been changed to new numba-dpex API
+      # - name: Run rodinia benchmarks
+      #   run: dpbench -i ${{env.WORKLOADS}} --last-run run -r2 --no-print-results --rodinia --no-dpbench --precision=${{matrix.precision}} || exit 1
 
       - name: Generate report
         run: dpbench -i ${{env.WORKLOADS}} report || exit 1

--- a/dpbench/benchmarks/default/black_scholes/black_scholes_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/black_scholes/black_scholes_numba_dpex_k.py
@@ -4,7 +4,7 @@
 
 from math import erf, exp, log, sqrt
 
-import numba_dpex.experimental as dpex
+import numba_dpex as dpex
 from numba_dpex import kernel_api as kapi
 
 

--- a/dpbench/benchmarks/default/dbscan/dbscan_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/dbscan/dbscan_numba_dpex_k.py
@@ -4,7 +4,7 @@
 
 import dpnp as np
 import numba as nb
-import numba_dpex.experimental as dpex
+import numba_dpex as dpex
 import numpy
 from numba_dpex import kernel_api as kapi
 

--- a/dpbench/benchmarks/default/gpairs/gpairs_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/gpairs/gpairs_numba_dpex_k.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numba_dpex as dpex
-import numba_dpex.experimental as dpexexp
 from numba_dpex import kernel_api as kapi
 
 # This implementation is numba dpex kernel version with atomics.
 
 
-@dpexexp.kernel
+@dpex.kernel
 def count_weighted_pairs_3d_intel_no_slm_ker(
     nd_item: kapi.NdItem,
     n,
@@ -151,7 +150,7 @@ def gpairs(
         ceiling_quotient(nbins, private_hist_size) * private_hist_size
     )
 
-    dpexexp.call_kernel(
+    dpex.call_kernel(
         count_weighted_pairs_3d_intel_no_slm_ker,
         kapi.NdRange(dpex.Range(*gwsRange), dpex.Range(*lwsRange)),
         nopt,

--- a/dpbench/benchmarks/default/kmeans/kmeans_initialize.py
+++ b/dpbench/benchmarks/default/kmeans/kmeans_initialize.py
@@ -17,7 +17,7 @@ def initialize(npoints, niters, seed, ndims, ncentroids, types_dict):
     arrayP = default_rng.uniform(XL, XH, (npoints, ndims)).astype(f_dtype)
     arrayPclusters = np.ones(npoints, dtype=i_dtype)
     arrayC = np.empty((ncentroids, ndims), dtype=f_dtype)
-    arrayCnumpoint = np.ones(ncentroids, dtype=i_dtype)
+    arrayCnumpoint = np.ones(ncentroids, dtype=np.int64)
 
     arrayC[:] = arrayP[:ncentroids]
 

--- a/dpbench/benchmarks/default/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_sycl.cpp
+++ b/dpbench/benchmarks/default/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_sycl.cpp
@@ -37,10 +37,6 @@ void kmeans_sync(dpctl::tensor::usm_ndarray arrayP,
         throw std::runtime_error("All arrays must have the same precision");
     }
 
-    if (arrayPclusters.get_typenum() != arrayCnumpoint.get_typenum()) {
-        throw std::runtime_error("All arrays must have the same precision");
-    }
-
     auto npoints = arrayP.get_shape(0);
     auto ncentroids = arrayC.get_shape(0);
     auto ndims = arrayC.get_shape(1);

--- a/dpbench/benchmarks/default/knn/knn_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/knn/knn_numba_dpex_k.py
@@ -5,12 +5,11 @@
 from math import sqrt
 
 import numba_dpex as dpex
-import numba_dpex.experimental as dpexexp
 import numpy as np
 from numba_dpex import kernel_api as kapi
 
 
-@dpexexp.kernel
+@dpex.kernel
 def _knn_kernel(  # noqa: C901: TODO: can we simplify logic?
     item: kapi.Item,
     train,
@@ -109,7 +108,7 @@ def knn(
     votes_to_classes,
     data_dim,
 ):
-    dpexexp.call_kernel(
+    dpex.call_kernel(
         _knn_kernel,
         kapi.Range(test_size),
         x_train,

--- a/dpbench/benchmarks/default/l2_norm/l2_norm_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/l2_norm/l2_norm_numba_dpex_k.py
@@ -4,7 +4,7 @@
 
 import math
 
-import numba_dpex.experimental as dpex
+import numba_dpex as dpex
 from numba_dpex import kernel_api as kapi
 
 

--- a/dpbench/benchmarks/default/pairwise_distance/pairwise_distance_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/pairwise_distance/pairwise_distance_numba_dpex_k.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dpnp as np
-import numba_dpex.experimental as dpex
+import numba_dpex as dpex
 from numba_dpex import kernel_api as kapi
 
 

--- a/dpbench/benchmarks/default/rambo/rambo_numba_dpex_k.py
+++ b/dpbench/benchmarks/default/rambo/rambo_numba_dpex_k.py
@@ -4,7 +4,7 @@
 
 from math import cos, log, pi, sin, sqrt
 
-import numba_dpex.experimental as dpex
+import numba_dpex as dpex
 from numba_dpex import kernel_api as kapi
 
 

--- a/dpbench/configs/bench_info/kmeans.toml
+++ b/dpbench/configs/bench_info/kmeans.toml
@@ -30,7 +30,7 @@ output_args = [
 ]
 # TODO: remove once fixed. Fails randomly
 # remove numba_dpex_k once atomics on SLM is implemented
-expected_failure_implementations = ["numba_mlir_k", "numba_dpex_k"]
+expected_failure_implementations = ["numba_mlir_k", "numba_dpex_k", "sycl"]
 
 [benchmark.parameters.S]
 npoints = 4096

--- a/dpbench/configs/bench_info/knn.toml
+++ b/dpbench/configs/bench_info/knn.toml
@@ -33,8 +33,7 @@ output_args = [
     "predictions",
 ]
 
-# `sycl` fails just on Windows
-expected_failure_implementations = ["numba_dpex_p", "sycl"]
+expected_failure_implementations = ["numba_dpex_p"]
 
 [benchmark.parameters.S]
 test_size = 1024

--- a/environments/conda-linux-sycl.yml
+++ b/environments/conda-linux-sycl.yml
@@ -23,7 +23,6 @@ dependencies:
   - dpctl
   - dpnp
   - numba-dpex
-  - numba-mlir
   # TODO: fix issues on conda-forge build
   - intel::dpcpp_linux-64==2024.0.0
   - intel::dpcpp-cpp-rt==2024.0.0

--- a/environments/conda-win-sycl.yml
+++ b/environments/conda-win-sycl.yml
@@ -23,7 +23,6 @@ dependencies:
   - dpctl
   - dpnp
   - numba-dpex
-  - numba-mlir
   # TODO: switch to conda-forge, but it results in broken OpenCL rt (see below)
   # - conda-forge::dpcpp_win-64
   - intel::dpcpp_win-64==2024.0.0

--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -24,4 +24,3 @@ dependencies:
   - dpctl
   - dpnp
   - numba-dpex
-  - numba-mlir


### PR DESCRIPTION
This PR removes all uses of experimental from numba_dpex_k implementations after numba-dpex made kernel decorator as the core feature.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
