### PR TITLE
Fix dpbench conda dep on python

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
       {% endif %}
     {% endfor %}
   run:
+    - python
     {% for dep in py_deps %}
     - {{ dep|replace('_','-') }}
     {% endfor %}


### PR DESCRIPTION
#349 removed `python` package dependency from conda run dependencies that resulted in similar package name generation regardless on the python version.

Thank you @adarshyoga for the report!

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
