### PR TITLE
fix: add security template for OpenSSF scoring

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Security Policy
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation.
+
+## Reporting a Vulnerability
+Please report any security vulnerabilities in this project utilizing the guidelines [here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation

SPDX-License-Identifier: Apache-2.0
-->

This adds a basic, suggested template for Intel security reporting.
It is the only thing missing for this repo in order for us to hit our OpenSSF scoring goals 

Please read the following links:
https://securityscorecards.dev/viewer/?uri=github.com/IntelPython/dpbench
https://wiki.ith.intel.com/display/SecTools/OpenSSF+Scorecard+Checks#OpenSSFScorecardChecks-ChecksWithMinimumScoreof0
https://github-vul-scan.intel.com/orgs/IntelPython/repos/dpbench/openssf
